### PR TITLE
ECCI-212: Changes all grey link boxes to have white background 

### DIFF
--- a/themes/custom/essex/css/overrides.css
+++ b/themes/custom/essex/css/overrides.css
@@ -130,3 +130,22 @@ input[type="submit"],
 .lgd-header .lgd-region--header {
     margin-right: 0;
 }
+
+/* Guide navigation */
+.lgd-guide-nav {
+    background-color: var(--color-white) !important;
+    border: 1px solid var(--color-black);
+}
+
+@media only screen and (min-width: 768px) {
+    .lgd-guide-nav__list-item {
+        margin-right: var(--spacing-large);
+    }
+}
+
+/* Sidebar blocks */
+.sidebar .lgd-region__inner > *,
+.blog-channel__sidebar > *,
+.newsroom__sidebar > * {
+    border: 1px solid var(--color-black);
+}

--- a/themes/custom/essex/css/variables.css
+++ b/themes/custom/essex/css/variables.css
@@ -54,4 +54,5 @@ body {
   --breadcrumbs-link-color: var(--color-black);
   --quote-author-color: var(--color-black);
   --tabs-button-bg-color: var(--color-grey-lighter);
+  --sidebar-exposed-form-bg-color: var(--color-white);
 }


### PR DESCRIPTION
And black border.

Components affected:
- Sidebar components (related topics etc.)
- Newsroom sidebars
- Guide contents component