### PR TITLE
ECCI-133: SSO supplied via env vars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ certs/
 /private
 
 # Ignore config which may contain secrets
-**/openid_connect.client.azure_b2c.yml
+.ddev/.env

--- a/assets/composer/settings.local.php
+++ b/assets/composer/settings.local.php
@@ -11,3 +11,18 @@ $databases['default']['default'] = array (
   'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
   'driver' => 'mysql',
 );
+
+if (getenv('OPENID_CONNECT_PARAMS') == true) {
+  $openid_config_params = json_decode(getenv('OPENID_CONNECT_PARAMS'), true);
+  $config['openid_connect.settings']['always_save_userinfo'] = $openid_config_params['always_save_userinfo'];
+  $config['openid_connect.settings']['connect_existing_users'] = $openid_config_params['connect_existing_users'];
+  $config['openid_connect.settings']['override_registration_settings'] = $openid_config_params['override_registration_settings'];
+  $config['openid_connect.settings']['end_session_enabled'] = $openid_config_params['end_session_enabled'];
+  $config['openid_connect.settings']['user_login_display'] = $openid_config_params['user_login_display'];
+  foreach($openid_config_params['clients'] as $client => $value) {
+    $config['openid_connect.client.' . $client]['status'] = $value['status'];
+    $config['openid_connect.client.' . $client]['settings']['tenant'] = $value['settings']['tenant'];
+    $config['openid_connect.client.' . $client]['settings']['client_id'] = $value['settings']['client_id'];
+    $config['openid_connect.client.' . $client]['settings']['client_secret'] = $value['settings']['client_secret'];
+  }
+}

--- a/config/default/openid_connect.client.essex.yml
+++ b/config/default/openid_connect.client.essex.yml
@@ -1,0 +1,19 @@
+uuid: b56c66df-b6af-4984-9f5e-bf94432f4c28
+langcode: en
+status: true
+dependencies:
+  module:
+    - openid_connect_azure_b2c
+id: essex
+label: Essex
+plugin: b2c
+settings:
+  client_id: placeholder
+  client_secret: placeholder
+  iss_allowed_domains: ''
+  tenant: placeholder
+  flow: B2C_1_signup_signin
+  scopes:
+    - openid
+    - email
+    - profile

--- a/config/default/openid_connect.client.nomensa.yml
+++ b/config/default/openid_connect.client.nomensa.yml
@@ -1,0 +1,19 @@
+uuid: 2972aee4-adcd-4aa2-b0b4-2e218f1cbcde
+langcode: en
+status: true
+dependencies:
+  module:
+    - openid_connect_azure_b2c
+id: nomensa
+label: Nomensa
+plugin: b2c
+settings:
+  client_id: placeholder
+  client_secret: placeholder
+  iss_allowed_domains: ''
+  tenant: placeholder
+  flow: B2C_1_signup_signin
+  scopes:
+    - openid
+    - email
+    - profile


### PR DESCRIPTION
This supplies:

- addition to `settings.local.php` to read an environment variable named `OPENID_CONNECT_PARAMS` and process it to assign the right values to access Azure B2C
- config files for the `openid_connect_client`s again with non-functioning data

The `OPENID_CONNECT_PARAMS` env var is a json string in this format:

```
{"always_save_userinfo":false,"connect_existing_users":true,"override_registration_settings":true,"end_session_enabled":true,"user_login_display":"above","redirect_login":"user","clients":{"nomensa":{"status":true,"settings":{"client_id":"clientid","client_secret":"secret_from_generated_key","tenant":"tenant_name"}},"essex":{"status":true,"settings":{"client_id":"clientid","client_secret":"secret_from_generated_key","tenant":"tenant_name"}}}}
```

To work with DDEV, the env file needs to be at `.ddev/.env`.

I'm anticipating that there could be deployment issues with UUID complaints with the config files. 