### PR TITLE
ECCI-217: Fixes broken groups admin dropdown.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,8 @@
             "drupal/entitygroupfield": {
                 "Breaks on fresh install": "patches/entitygroupfield-install.patch",
                 "\"Drupal\\group\\Entity\\GroupContent\" unexpected error": "https://www.drupal.org/files/issues/2022-10-14/issue-3315323-3.patch",
-                "Support for Groups v3": "patches/entitygroupfield-groupv3-2.patch"
+                "Support for Groups v3": "patches/entitygroupfield-groupv3-2.patch",
+                "Broken dropbutton in Groups field when used with Claro": "https://www.drupal.org/files/issues/2022-04-04/entitygroupfield-matching-expected-dropbutton-markup-3183134-6.patch"
             },
             "localgovdrupal/localgov_alert_banner": {
                 "Increase size of title field": "patches/localgov_alert_banner.patch"


### PR DESCRIPTION
Turns this:

![image](https://user-images.githubusercontent.com/158008/225264130-7fe61161-7cc3-4d98-9133-94b400e22c2b.png)

into this

![image](https://user-images.githubusercontent.com/158008/225262877-7fe4bd2d-b576-473f-b9d5-a0ab50428d86.png)
