### PR TITLE
ECCI-269: The small 3:2 image is now max-width 360px only.

### DIFF
--- a/config/default/image.style.small_360x200.yml
+++ b/config/default/image.style.small_360x200.yml
@@ -1,0 +1,15 @@
+uuid: c3aaea6a-308b-49b9-bf81-e8a8ded2ecc8
+langcode: en
+status: true
+dependencies: {  }
+name: small_360x200
+label: 'Small (360w)'
+effects:
+  bdd20af8-d333-4dc1-be2b-e445f81413bb:
+    uuid: bdd20af8-d333-4dc1-be2b-e445f81413bb
+    id: image_scale
+    weight: 1
+    data:
+      width: 360
+      height: null
+      upscale: false

--- a/config/default/responsive_image.styles.3_2_image.yml
+++ b/config/default/responsive_image.styles.3_2_image.yml
@@ -5,7 +5,7 @@ dependencies:
   config:
     - image.style.large_3_2_2x
     - image.style.large_3_2_768x512
-    - image.style.small_scale_crop_360x620
+    - image.style.small_360x200
   module:
     - localgov_media
 _core:
@@ -28,7 +28,7 @@ image_style_mappings:
     image_mapping:
       sizes: '(max-width: 400px) 400px, 100vh.'
       sizes_image_styles:
-        - small_scale_crop_360x620
+        - small_360x200
     breakpoint_id: localgov_media.bootstrap4_xs
     multiplier: 1x
 breakpoint_group: localgov_media


### PR DESCRIPTION
This makes the responsive image styling for the 3:2 images the same as it is on .gov.