### PR TITLE
ECCI-328: Adding the newer version of content_ownership.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7993,12 +7993,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/essexcountycouncil/content_ownership.git",
-                "reference": "1c6b80b3e41fc28f85db15139d700370908e7a4e"
+                "reference": "94cb52bfa5684f585bd0cc0a6a116a181f2e1f02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/essexcountycouncil/content_ownership/zipball/1c6b80b3e41fc28f85db15139d700370908e7a4e",
-                "reference": "1c6b80b3e41fc28f85db15139d700370908e7a4e",
+                "url": "https://api.github.com/repos/essexcountycouncil/content_ownership/zipball/94cb52bfa5684f585bd0cc0a6a116a181f2e1f02",
+                "reference": "94cb52bfa5684f585bd0cc0a6a116a181f2e1f02",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8014,7 +8014,7 @@
                 "source": "https://github.com/essexcountycouncil/content_ownership/tree/main",
                 "issues": "https://github.com/essexcountycouncil/content_ownership/issues"
             },
-            "time": "2022-12-01T09:58:36+00:00"
+            "time": "2023-06-05T17:21:55+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",


### PR DESCRIPTION
Just adds the [newer version of the content ownership module](https://github.com/essexcountycouncil/content_ownership/pull/8).