### PR TITLE
ECCI-342 & 323: Adds a max-height to default media with text component and reduces padding below quick actions

### DIFF
--- a/themes/custom/essex/css/overrides.css
+++ b/themes/custom/essex/css/overrides.css
@@ -421,6 +421,24 @@ nav.lgd-prev-next ul.lgd-prev-next__list li {
   margin-top: var(--spacing-large);
 }
 
+.media-with-text--default .media-with-text__media img {
+  max-height: 200px;
+  width: 100%;
+  object-fit: cover;
+}
+
+@media screen and (min-width: 640px) {
+  .media-with-text--default .media-with-text__media img {
+    max-height: 250px;
+  }
+}
+
+@media screen and (min-width: 890px) {
+  .media-with-text--default .media-with-text__media img {
+    max-height: none;
+  }
+}
+
 .media-with-text--featured {
   position: relative;
   overflow: hidden;
@@ -1012,6 +1030,12 @@ tbody tr {
   max-height: clamp(260px, 35vw, 1000px);
   width: 100%;
   object-fit: cover;
+}
+
+@media only screen and (max-width: 640px) {
+  .layout:not(.layout--onecol) .media-with-text:not(.media-with-text--featured) .media-with-text__media * {
+    max-height: 200px;
+  }
 }
 
 .layout__region:empty {

--- a/themes/custom/essex/css/overrides.css
+++ b/themes/custom/essex/css/overrides.css
@@ -429,7 +429,7 @@ nav.lgd-prev-next ul.lgd-prev-next__list li {
 
 @media screen and (min-width: 640px) {
   .media-with-text--default .media-with-text__media img {
-    max-height: 250px;
+    max-height: none;
   }
 }
 
@@ -1002,6 +1002,12 @@ tbody tr {
 .field__item:first-of-type .field--name-localgov-text:has(> h2),
 .path-frontpage article>.field__items {
   padding-top: clamp(0.75rem, 2vw, var(--spacing))
+}
+
+@media only screen and (max-width: 760px) {
+  .path-frontpage article>.field__items {
+    padding-top: 0.25rem;
+  }
 }
 
 .branding__item--logo {


### PR DESCRIPTION
- Adds a max-height of 200px to default media with text component on mobile, 250px on small tablet
- Reduces padding between Quick Actions and the content below it