### PR TITLE
ECCI-359: Move footer menu admin link to bottom of Content menu.

### DIFF
--- a/config/default/core.menu.static_menu_link_overrides.yml
+++ b/config/default/core.menu.static_menu_link_overrides.yml
@@ -55,3 +55,9 @@ definitions:
     weight: 9
     expanded: false
     enabled: true
+  'admin_toolbar_tools__extra_links:entity__menu__edit_form__footer':
+    menu_name: admin
+    parent: system.admin_content
+    weight: 50
+    expanded: false
+    enabled: true


### PR DESCRIPTION
Adds:
<img width="360" alt="image" src="https://github.com/essexcountycouncil/essex-intranet-drupal/assets/158008/414858b4-52cd-4131-a28e-695ef86c118c">
