### PR TITLE
Draft: ECCI-000: Prevent images from being added to ACR automatically.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,9 +43,11 @@ build-and-push-images:
     - docker push ${DOCKER_REGISTRY}/intranet-nginx-drupal
     - docker push ${DOCKER_REGISTRY}/intranet-drupal-fpm${tag}
     - docker push ${DOCKER_REGISTRY}/intranet-drupal-fpm
-  only:
-    - develop
-    - /^release\//
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "develop"'
+      when: manual
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: manual
 
 deploy-to-dev:
   image: mcr.microsoft.com/azure-cli


### PR DESCRIPTION
As the dev env autoscales to zero, the dev environment always resurrects itself with the latest develop branch, and we may not completely realise it and this may not be the desired effect. It may be necessary to run `drush deploy` for starters, and that could be overlooked.

This is an attempt to keep that uncertainty from happening.