### PR TITLE
ECCI-361: Breadcrumbs don't display on subsite_overview pages anyway.

### DIFF
--- a/config/default/block.block.essex_localgov_breadcrumbs_scarfolk.yml
+++ b/config/default/block.block.essex_localgov_breadcrumbs_scarfolk.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - node
     - system
   theme:
     - essex
@@ -20,27 +19,4 @@ settings:
   label: Breadcrumbs
   label_display: '0'
   provider: system
-visibility:
-  'entity_bundle:node':
-    id: 'entity_bundle:node'
-    negate: false
-    context_mapping:
-      node: '@node.node_route_context:node'
-    bundles:
-      localgov_directories_org: localgov_directories_org
-      localgov_directories_page: localgov_directories_page
-      localgov_directories_venue: localgov_directories_venue
-      localgov_directory: localgov_directory
-      localgov_directory_promo_page: localgov_directory_promo_page
-      localgov_event: localgov_event
-      localgov_guides_overview: localgov_guides_overview
-      localgov_guides_page: localgov_guides_page
-      localgov_newsroom: localgov_newsroom
-      localgov_news_article: localgov_news_article
-      localgov_services_landing: localgov_services_landing
-      localgov_services_page: localgov_services_page
-      localgov_services_status: localgov_services_status
-      localgov_services_sublanding: localgov_services_sublanding
-      localgov_step_by_step_overview: localgov_step_by_step_overview
-      localgov_step_by_step_page: localgov_step_by_step_page
-      localgov_subsites_page: localgov_subsites_page
+visibility: {  }


### PR DESCRIPTION
By deselecting all of the content types in the breadcrumb's block config page (making it so that the breadcrumbs will display on every page) they then appear on the `/csearch` cludo page.

There was only one content type which didn't have the tickbox displaying prior to this: the `subsite_overview` content type. Even after making this change the breadcrumbs do not display on `subsite_overview` pages anyway.

So having tried to code my way out of this, in the end, the **no code** approach was the right solution.