### PR TITLE
ECCI-449: Reinstall Simple XML Sitemap module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "drupal/permissions_filter": "^1.3",
         "drupal/published_corrected_date": "^2.0",
         "drupal/restui": "^1.21",
+        "drupal/simple_sitemap": "^4.1",
         "drupal/smtp": "^1.2",
         "drupal/stage_file_proxy": "^2.0",
         "drupal/ultimate_cron": "^2.0@alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2a378f2737a1b6d6c214b8d6b12444c",
+    "content-hash": "4a4690329443daf56d475f977062ce1a",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -6,7 +6,7 @@ ignored_config_entities:
   - devel.toolbar.settings
   - devel.settings
   - oidc_auto_login.settings
-  - simple_sitemap.settings
+  - 'simple_sitemap.settings:base_url'
   - system.menu.devel
   - 'webform.webform.*'
   - 'webform.webform_options.*'

--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -5,6 +5,8 @@ ignored_config_entities:
   - 'cludo_search.settings:engineId'
   - devel.toolbar.settings
   - devel.settings
+  - oidc_auto_login.settings
+  - simple_sitemap.settings
   - system.menu.devel
   - 'webform.webform.*'
   - 'webform.webform_options.*'

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -170,6 +170,7 @@ module:
   search_api_location_geocoder: 0
   search_api_location_views: 0
   serialization: 0
+  simple_sitemap: 0
   smtp: 0
   sophron: 0
   system: 0

--- a/config/default/facets.facet.localgov_events_locality.yml
+++ b/config/default/facets.facet.localgov_events_locality.yml
@@ -6,20 +6,16 @@ _core:
   default_config_hash: AkfpWU5b5M60WRVm_3oVtKiqGgv1A9X9Pr7laZlkxuc
 id: localgov_events_locality
 name: Neighbourhood
-url_alias: locality
 weight: 0
 min_count: 1
 missing: false
 missing_label: others
-show_only_one_result: false
-field_identifier: localgov_event_locality
+url_alias: locality
 facet_source_id: 'search_api:views_page__localgov_events_search__events_page'
-widget:
-  type: dropdown
-  config:
-    show_numbers: false
-    default_option_label: '- All -'
+field_identifier: localgov_event_locality
 query_operator: or
+hard_limit: 0
+exclude: false
 use_hierarchy: false
 keep_hierarchy_parents_active: false
 hierarchy:
@@ -27,9 +23,16 @@ hierarchy:
   config: {  }
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
-hard_limit: 0
-exclude: false
+widget:
+  type: dropdown
+  config:
+    show_numbers: false
+    default_option_label: '- All -'
+empty_behavior:
+  behavior: none
 only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: true
 processor_configs:
   term_weight_widget_order:
     processor_id: term_weight_widget_order
@@ -48,6 +51,3 @@ processor_configs:
       pre_query: 50
       build: 15
     settings: {  }
-empty_behavior:
-  behavior: none
-show_title: true

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_directories_page.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_directories_page.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_directories_venue.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_directories_venue.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_directory.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_directory.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_directory_promo_page.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_directory_promo_page.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_event.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_event.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_guides_overview.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_guides_overview.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_guides_page.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_guides_page.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_news_article.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_news_article.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_newsroom.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_newsroom.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_services_landing.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_services_landing.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_services_page.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_services_page.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_services_status.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_services_status.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_services_sublanding.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_services_sublanding.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_step_by_step_overview.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_step_by_step_overview.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_step_by_step_page.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_step_by_step_page.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_subsites_overview.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_subsites_overview.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.bundle_settings.default.node.localgov_subsites_page.yml
+++ b/config/default/simple_sitemap.bundle_settings.default.node.localgov_subsites_page.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/config/default/simple_sitemap.custom_links.default.yml
+++ b/config/default/simple_sitemap.custom_links.default.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: _iOvXq8pAkn81anJ32ELiAx746QP86Z4PyXz514puXQ
+links:
+  -
+    path: /
+    priority: '1.0'
+    changefreq: daily

--- a/config/default/simple_sitemap.settings.yml
+++ b/config/default/simple_sitemap.settings.yml
@@ -1,0 +1,20 @@
+_core:
+  default_config_hash: 2CVQWCMHHIqT_kLCVL_IRfqt8HP9IrnehZNbhXk2jZ0
+max_links: 2000
+cron_generate: true
+cron_generate_interval: 0
+generate_duration: 10000
+entities_per_queue_item: 50
+remove_duplicates: true
+skip_untranslated: true
+xsl: true
+base_url: 'https://beta.intranet.essex.gov.uk'
+default_variant: default
+custom_links_include_images: false
+disable_language_hreflang: false
+hide_branding: false
+excluded_languages: {  }
+enabled_entity_types:
+  - node
+  - taxonomy_term
+  - menu_link_content

--- a/config/default/simple_sitemap.sitemap.default.yml
+++ b/config/default/simple_sitemap.sitemap.default.yml
@@ -1,0 +1,13 @@
+uuid: 9373cd5a-50f2-4bb2-bc81-6b4ba9f8b2f7
+langcode: en
+status: true
+dependencies:
+  config:
+    - simple_sitemap.type.default_hreflang
+_core:
+  default_config_hash: zHW-ZT11Lkf2zSRgisGKjgU7TzrNcT8_MwFeuVtl8O8
+id: default
+label: Default
+description: 'The default hreflang sitemap - lists URLs to be indexed by modern search engines.'
+type: default_hreflang
+weight: 0

--- a/config/default/simple_sitemap.sitemap.index.yml
+++ b/config/default/simple_sitemap.sitemap.index.yml
@@ -1,0 +1,13 @@
+uuid: ae8dac86-596a-4ec5-b541-045effb6d8ff
+langcode: en
+status: false
+dependencies:
+  config:
+    - simple_sitemap.type.index
+_core:
+  default_config_hash: aJs7eKxEbjBloVrp0IuxQbeq25CNH0r9AhSS29kHFMw
+id: index
+label: 'Sitemap Index'
+description: 'The sitemap index listing all other sitemaps - useful if there are at least two other sitemaps. In most cases this sitemap should be last in the generation queue and set as the default sitemap.'
+type: index
+weight: 1000

--- a/config/default/simple_sitemap.type.default_hreflang.yml
+++ b/config/default/simple_sitemap.type.default_hreflang.yml
@@ -1,0 +1,15 @@
+uuid: af4d89a9-bca6-4509-8d8c-8fec33deebaf
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: pYORFuFzL0b2FKevz6fSag1wOUNTthFPPLxZ18JB1t0
+id: default_hreflang
+label: 'Default hreflang'
+description: 'The default hreflang sitemap type. A sitemap of this type is understood by most modern search engines.'
+sitemap_generator: default
+url_generators:
+  - custom
+  - entity
+  - entity_menu_link_content
+  - arbitrary

--- a/config/default/simple_sitemap.type.index.yml
+++ b/config/default/simple_sitemap.type.index.yml
@@ -1,0 +1,12 @@
+uuid: 5bc1452d-16e5-4f81-83fb-47893e258cb2
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: pbgJrin6L7zsVEKS8oEDCYJPCzgu765iTGQh2GPX1no
+id: index
+label: 'Sitemap Index'
+description: 'The sitemap index sitemap type. A sitemap of this type lists sitemaps of all other types.'
+sitemap_generator: index
+url_generators:
+  - index


### PR DESCRIPTION
ECCI-449 - Sitemap module was removed from Intranet (ECCI-388) but is required for Cludo search

- Enable the module
- Set all content types to be indexed
- Set base url to https://beta.intranet.essex.gov.uk/
- Add simple_sitemap.settings to Config Ignore so base URL can be changed per environment

ECCI-386 - add oidc_auto_login.settings to Config Ignore so that it can be disabled on some environments