### PR TITLE
ECCI-471: reduce space between hero and content

### DIFF
--- a/themes/custom/essex/css/preliminary.css
+++ b/themes/custom/essex/css/preliminary.css
@@ -11,7 +11,67 @@
   }
 }
 
+.layout--twocol > .layout__region > .paragraph--type--localgov-media-with-text {
+  margin: var(--spacing-larger) 0 0;
+}
+
 .layout--twocol > .layout__region > .paragraph--type--localgov-media-with-text:last-child {
-  /* from https://essex-intranet.ddev.site/themes/contrib/localgov_base/css/base/variables.css?s34rq6 */
   margin-top: var(--spacing);
+}
+
+@media screen and (min-width: 1025px) {
+  .layout--twocol > .layout__region > .paragraph--type--localgov-media-with-text:last-child {
+    margin-top: var(--spacing-largest);
+  }
+}
+
+/* Added for https://nomensa.atlassian.net/browse/ECCI-471 */
+.field--name-localgov-subsites-content > .field__item:first-child {
+  margin-top: 0px;
+}
+
+.field--name-localgov-subsites-content > .field__item:first-child .layout__region--first {
+  margin-top: 0px;
+}
+
+.field--name-localgov-subsites-content > .field__item:first-child .layout__region--first > .paragraph--type--localgov-text > .field--name-localgov-text {
+  padding-top: 0px;
+}
+
+.featured-news__card:first-of-type, .news-card article {
+  margin-bottom: var(--spacing);
+}
+
+.featured-news__card article {
+  margin-bottom: 0px;
+}
+
+.paragraph--type--page-section .layout--twocol > .layout__region--second {
+  padding-left: 0px;
+}
+
+@media screen and (min-width: 1025px) {
+  .field--name-localgov-subsites-content > .field__item:first-child {
+    margin: var(--spacing-largest) clamp(var(--spacing-smallest), 2.5vw, var(--spacing-largest))
+  }
+
+  .field--name-localgov-subsites-content > .field__item:first-child .layout__region--first {
+    margin: var(--spacing-larger) 0;
+  }
+
+  .field--name-localgov-subsites-content > .field__item:first-child .layout__region--first > .paragraph--type--localgov-text > .field--name-localgov-text {
+    padding-top: clamp(0.75rem, 2vw, var(--spacing));
+  }
+
+  .featured-news__card article, .news-card article {
+    margin-bottom: var(--spacing-large);
+  }
+
+  .featured-news__card:first-of-type {
+    margin-bottom: var(--spacing-largest);
+  }
+
+  .paragraph--type--page-section .layout--twocol > .layout__region--second {
+    padding-left: calc(var(--spacing-largest) / 2);
+  }
 }

--- a/themes/custom/essex/css/preliminary.css
+++ b/themes/custom/essex/css/preliminary.css
@@ -46,7 +46,11 @@
   margin-bottom: 0px;
 }
 
-.paragraph--type--page-section .layout--twocol > .layout__region--second {
+.field--name-localgov-subsites-content > .field__item:first-child .paragraph--type--page-section .layout--twocol > .layout__region--first {
+  padding-right: 0px;
+}
+
+.field--name-localgov-subsites-content > .field__item:first-child .paragraph--type--page-section .layout--twocol > .layout__region--second {
   padding-left: 0px;
 }
 
@@ -71,7 +75,11 @@
     margin-bottom: var(--spacing-largest);
   }
 
-  .paragraph--type--page-section .layout--twocol > .layout__region--second {
+  .field--name-localgov-subsites-content > .field__item:first-child .paragraph--type--page-section .layout--twocol > .layout__region--first {
+    padding-right: calc(var(--spacing-largest) / 2);
+  }
+
+  .field--name-localgov-subsites-content > .field__item:first-child .paragraph--type--page-section .layout--twocol > .layout__region--second {
     padding-left: calc(var(--spacing-largest) / 2);
   }
 }


### PR DESCRIPTION
...and also between media and text components on tablet.

- Tested and can confirm these styles will affect the media and text components only
- Styles will only work if configuration of page is as shown in the ticket
- Order:
 - text component
 - ...rest of components
 - the styles targets the first field in the page and then goes into that field and alters the margin of the component section
- Also had to alter the padding on the `.layout--twocol > .layout__region--second`