### PR TITLE
Switch B2C to an official release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,6 @@
         },
         {
             "type": "github",
-            "url":  "https://github.com/MatthewWilkes/openid_connect_azure_b2c"
-        },
-        {
-            "type": "github",
             "url":  "https://github.com/essexcountycouncil/ecc_menu"
         },
         {
@@ -77,6 +73,7 @@
         "drupal/menu_item_limit": "^2.0",
         "drupal/monolog": "^2.2",
         "drupal/office_hours": "^1.11",
+        "drupal/openid_connect_azure_b2c": "^1.0@beta",
         "drupal/permissions_filter": "^1.3",
         "drupal/published_corrected_date": "^2.0",
         "drupal/restui": "^1.21",
@@ -92,8 +89,7 @@
         "localgovdrupal/localgov": "^2.0",
         "localgovdrupal/localgov_base": "^1.4",
         "localgovdrupal/localgov_eu_cookie_compliance": " 1.x-dev",
-        "localgovdrupal/localgov_forms": "1.x-dev",
-        "matthewwilkes/openid_connect_azure_b2c": "dev-main"
+        "localgovdrupal/localgov_forms": "1.x-dev"
     },
     "require-dev": {
         "brianium/paratest": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "163ca1cc2f7795b78eb163c42c13d05d",
+    "content-hash": "ed82f160f80426946e82929dc3e96ae8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -6559,6 +6559,63 @@
             }
         },
         {
+            "name": "drupal/openid_connect_azure_b2c",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/openid_connect_azure_b2c.git",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/openid_connect_azure_b2c-1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": "7f59c13c1696c8792fbe80511808acb6dbd7c896"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "drupal/openid_connect": "^2.0@beta"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0",
+                    "datestamp": "1695837259",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "andystone78",
+                    "homepage": "https://www.drupal.org/user/263722"
+                },
+                {
+                    "name": "MatthewWilkes",
+                    "homepage": "https://www.drupal.org/user/3708219"
+                },
+                {
+                    "name": "polynya",
+                    "homepage": "https://www.drupal.org/user/795122"
+                },
+                {
+                    "name": "siliconmeadow",
+                    "homepage": "https://www.drupal.org/user/55284"
+                }
+            ],
+            "description": "Azure B2C plugin for the OpenID Connect module.",
+            "homepage": "https://www.drupal.org/project/openid_connect_azure_b2c",
+            "support": {
+                "source": "https://git.drupalcode.org/project/openid_connect_azure_b2c"
+            }
+        },
+        {
             "name": "drupal/paragraphs",
             "version": "1.15.0",
             "source": {
@@ -10720,35 +10777,6 @@
                 "source": "https://github.com/Masterminds/html5-php/tree/2.7.6"
             },
             "time": "2022-08-18T16:18:26+00:00"
-        },
-        {
-            "name": "matthewwilkes/openid_connect_azure_b2c",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/MatthewWilkes/openid_connect_azure_b2c.git",
-                "reference": "1e0877e4aa6c5ba8062fe535d16e18bce4ff7ca8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/MatthewWilkes/openid_connect_azure_b2c/zipball/1e0877e4aa6c5ba8062fe535d16e18bce4ff7ca8",
-                "reference": "1e0877e4aa6c5ba8062fe535d16e18bce4ff7ca8",
-                "shasum": ""
-            },
-            "require": {
-                "drupal/openid_connect": "^2.0@beta"
-            },
-            "default-branch": true,
-            "type": "drupal-module",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Azure B2C plugin for the OpenID Connect module.",
-            "support": {
-                "source": "https://github.com/MatthewWilkes/openid_connect_azure_b2c/tree/main",
-                "issues": "https://github.com/MatthewWilkes/openid_connect_azure_b2c/issues"
-            },
-            "time": "2023-01-27T17:18:54+00:00"
         },
         {
             "name": "mkalkbrenner/php-htmldiff-advanced",
@@ -20311,11 +20339,11 @@
         "drupal/cludo_search": 10,
         "drupal/config_split": 5,
         "drupal/gin": 5,
+        "drupal/openid_connect_azure_b2c": 10,
         "drupal/ultimate_cron": 15,
         "essexcountycouncil/content_ownership": 20,
         "localgovdrupal/localgov_eu_cookie_compliance": 20,
         "localgovdrupal/localgov_forms": 20,
-        "matthewwilkes/openid_connect_azure_b2c": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
Move the B2C login from a dev release to the Drupal release. Pin to beta, to allow Drupal 10 support.