### PR TITLE
ECCI-488: Feature switch for the Restricted content form element

### DIFF
--- a/modules/custom/localgov_restricted_content/localgov_restricted_content.module
+++ b/modules/custom/localgov_restricted_content/localgov_restricted_content.module
@@ -10,6 +10,9 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeForm;
 
+// To enable identify whether the "Restricted content" flag is available.
+const RESTRICTED_CONTENT_FORM_FLAG = TRUE;
+
 /**
  * Implements hook_entity_view_mode_alter().
  */
@@ -50,6 +53,21 @@ function localgov_restricted_content_form_node_form_alter(&$form, FormStateInter
   if ($restricted_content->isAncestorRestricted($entity)) {
     $form['localgov_restricted_content']['#suffix'] = t('<div class="form-item__label option">This is disabled because the page\'s parent is restricted.</div>');
     $form['localgov_restricted_content']['#disabled'] = TRUE;
+  }
+
+  // Determine whether to hide the Restricted content portion of the node edit
+  // form.
+  if (RESTRICTED_CONTENT_FORM_FLAG) {
+    switch ($form_id) {
+      case 'node_localgov_news_article_edit_form':
+      case 'node_localgov_newsroom_edit_form':
+        break;
+
+      default:
+        $form['localgov_restricted_content']['#disabled'] = TRUE;
+        break;
+
+    }
   }
 }
 


### PR DESCRIPTION
# Summary
- Adds a constant to enable/disable the feature altogether
- If enabled, a check of the content type is made to determine whether the form element should be disabled
# Implementation decisions
- This allows the existing work in progress to remain and not hinder progress with interim releases.
- **Caveat no. 1**: If content of anything type other than `news_article` or `newsroom` have been marked as `Restricted content` they won't be able to be unmarked until the feature is switched off.
- **Caveat no. 2**: There is no GUI interface to enable/disable this - it requires a tweak to code and a deployment
- **Caveat no. 3**: Editors will see the `Restricted content` form element on all content types still, but will be unable to change it when this is enabled.