### PR TITLE
ECCI-464: Add a component to the bottom of newsroom pages.

### DIFF
--- a/config/default/core.entity_form_display.node.localgov_newsroom.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_newsroom.default.yml
@@ -3,14 +3,17 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.page_components
     - field.field.node.localgov_newsroom.field_content_owner
     - field.field.node.localgov_newsroom.field_content_sme
-    - field.field.node.localgov_newsroom.localgov_restricted_content
     - field.field.node.localgov_newsroom.localgov_newsroom_featured
+    - field.field.node.localgov_newsroom.localgov_page_components
+    - field.field.node.localgov_newsroom.localgov_restricted_content
     - node.type.localgov_newsroom
     - workflows.workflow.localgov_editorial
   module:
     - content_moderation
+    - entity_browser
     - field_group
     - localgov_review_date
     - path
@@ -25,7 +28,7 @@ third_party_settings:
       label: Privacy
       region: content
       parent_name: ''
-      weight: -1
+      weight: 0
       format_type: details_sidebar
       format_settings:
         classes: ''
@@ -44,13 +47,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 4
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_content_owner:
     type: entity_reference_autocomplete
-    weight: 12
+    weight: 14
     region: content
     settings:
       match_operator: CONTAINS
@@ -60,7 +63,7 @@ content:
     third_party_settings: {  }
   field_content_sme:
     type: entity_reference_autocomplete
-    weight: 13
+    weight: 15
     region: content
     settings:
       match_operator: CONTAINS
@@ -70,13 +73,27 @@ content:
     third_party_settings: {  }
   localgov_newsroom_featured:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  localgov_page_components:
+    type: entity_browser_entity_reference
+    weight: 4
+    region: content
+    settings:
+      entity_browser: page_components
+      field_widget_display: label
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: false
+      field_widget_display_settings: {  }
+      selection_mode: selection_append
     third_party_settings: {  }
   localgov_restricted_content:
     type: boolean_checkbox
@@ -87,51 +104,51 @@ content:
     third_party_settings: {  }
   localgov_review_date:
     type: review_date
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 11
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 5
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 9
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 8
+    weight: 10
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 6
+    weight: 8
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -139,7 +156,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 3
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS
@@ -148,7 +165,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/default/core.entity_view_display.node.localgov_newsroom.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_newsroom.default.yml
@@ -6,9 +6,11 @@ dependencies:
     - field.field.node.localgov_newsroom.field_content_owner
     - field.field.node.localgov_newsroom.field_content_sme
     - field.field.node.localgov_newsroom.localgov_newsroom_featured
+    - field.field.node.localgov_newsroom.localgov_page_components
     - field.field.node.localgov_newsroom.localgov_restricted_content
     - node.type.localgov_newsroom
   module:
+    - field_formatter_class
     - user
   enforced:
     module:
@@ -31,7 +33,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
   field_content_sme:
     type: entity_reference_label
@@ -39,22 +41,22 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 7
+    weight: 8
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   localgov_news_facets:
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   localgov_news_search:
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   localgov_newsroom_all_view:
     settings: {  }
@@ -67,8 +69,21 @@ content:
     settings:
       view_mode: teaser
       link: false
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: ''
     weight: 1
+    region: content
+  localgov_page_components:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+    weight: 3
     region: content
 hidden:
   entitygroupfield: true

--- a/config/default/core.entity_view_display.node.localgov_newsroom.full_anonymous.yml
+++ b/config/default/core.entity_view_display.node.localgov_newsroom.full_anonymous.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_newsroom.field_content_owner
     - field.field.node.localgov_newsroom.field_content_sme
     - field.field.node.localgov_newsroom.localgov_newsroom_featured
+    - field.field.node.localgov_newsroom.localgov_page_components
     - field.field.node.localgov_newsroom.localgov_restricted_content
     - node.type.localgov_newsroom
   module:
@@ -36,6 +37,7 @@ hidden:
   localgov_news_search: true
   localgov_newsroom_all_view: true
   localgov_newsroom_featured: true
+  localgov_page_components: true
   localgov_restricted_content: true
   restricted_content_sign_in: true
   search_api_excerpt: true

--- a/config/default/field.field.node.localgov_newsroom.localgov_page_components.yml
+++ b/config/default/field.field.node.localgov_newsroom.localgov_page_components.yml
@@ -1,0 +1,26 @@
+uuid: 00f80985-a644-4b67-adf9-681ddbd36d08
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_page_components
+    - node.type.localgov_newsroom
+id: node.localgov_newsroom.localgov_page_components
+field_name: localgov_page_components
+entity_type: node
+bundle: localgov_newsroom
+label: 'Page components'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraphs_library_item'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+field_type: entity_reference

--- a/config/default/field.storage.node.localgov_page_components.yml
+++ b/config/default/field.storage.node.localgov_page_components.yml
@@ -15,7 +15,7 @@ settings:
   target_type: paragraphs_library_item
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/themes/custom/essex/css/preliminary.css
+++ b/themes/custom/essex/css/preliminary.css
@@ -199,3 +199,12 @@
   font-size: calc(var(--spacing) * 1.875);
   font-family: var(--font-heading-3);
 }
+
+/* Added for https://nomensa.atlassian.net/browse/ECCI-481 */
+.newsroom-teaser,
+.featured-news__card article,
+.news-card article {
+  word-wrap: break-word;
+}
+
+/* End of https://nomensa.atlassian.net/browse/ECCI-481 */


### PR DESCRIPTION
# Summary
This provides editors the option to add a single page component to the bottom of newsroom pages using the pattern used for doing so on service pages.
# Screenshots
- The add/edit page:
![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/158008/e2ff0bf9-5401-43b1-a42d-fc9535337509)

- The default display:
![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/158008/dc912ead-ed62-4ae0-b8b2-715526b92903)
