### PR TITLE
ECCI-425: Update nginx config with fixed noindex support

### DIFF
--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,16 +1,6 @@
-FROM docker.io/nginx:1.22 as nginx-drupal
+FROM nginx
 
-RUN apt-get update \
-  && apt-get install -y \
-  wget \
-  && mkdir -p /drupal/web/sites/default/files \
-  && echo "Server running" > /drupal/web/index.html \
-  && usermod -d /drupal www-data
-
-RUN chown -hR 33:33 /drupal
-
+ENV X_ROBOTS_TAG="none"
+ENV LIMITED_BETA_MODE="0"
 COPY --chown=www-data:www-data --from=intranet-drupal-fpm /drupal /drupal
-
-COPY nginx-conf/nginx.conf /etc/nginx/nginx.conf
-
-EXPOSE 80
+COPY nginx-conf/nginx.conf /etc/nginx/templates/default.conf.template

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -1,154 +1,196 @@
-worker_processes  1;
+server {
+    listen 80;
+    server_name localhost;
+    root /drupal/web; ## <-- Your only path reference.
 
-events {
-    worker_connections  1024;
-}
-
-http {
-    include       mime.types;
-    default_type  application/octet-stream;
-
-    sendfile        on;
-    server_tokens off;
-    keepalive_timeout  65;
-
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
     client_max_body_size 120M;
 
-    server {
-        listen 80;
-        server_name localhost;
-        root /drupal/web; ## <-- Your only path reference.
+    # Determine HTTP host to use based on forwarding headers
+    set $customhost $http_host;
+    if ($http_x_forwarded_host != '') {
+        set $customhost $http_x_forwarded_host;
+    }
+    if ($http_x_original_host != '') {
+        set $customhost $http_x_original_host;
+    }
 
-        access_log /var/log/nginx/access.log;
-        error_log /var/log/nginx/error.log;
+    # If CANONICAL_HOST is set and does not match the current host then
+    # redirect to the canonical url.
+    set $canonical_host '${CANONICAL_HOST}';
+    if ($canonical_host = '') {
+        set $canonical_host $customhost;
+    }
+    if ($customhost != $canonical_host) {
+        return 302 https://$canonical_host$request_uri;
+    }
 
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
 
-        location = /favicon.ico {
-            log_not_found off;
-            access_log off;
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    # Very rarely should these ever be accessed outside of your lan
+    location ~* \.(txt|log)$ {
+        allow 192.168.0.0/16;
+        deny all;
+    }
+
+    location ~ \..*/.*\.php$ {
+        return 403;
+    }
+
+    location ~ ^/sites/.*/private/ {
+        return 403;
+    }
+
+    # Block access to scripts in site files directory
+    location ~ ^/sites/[^/]+/files/.*\.php$ {
+        deny all;
+    }
+
+    # Allow "Well-Known URIs" as per RFC 5785
+    location ~* ^/.well-known/ {
+        allow all;
+    }
+
+    # Block access to "hidden" files and directories whose names begin with a
+    # period. This includes directories used by version control systems such
+    # as Subversion or Git to store control files.
+    location ~ (^|/)\. {
+        return 403;
+    }
+
+    location / {
+        # try_files $uri @rewrite; # For Drupal <= 6
+        try_files $uri /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location @rewrite {
+        #rewrite ^/(.*)$ /index.php?q=$1; # For Drupal <= 6
+        rewrite ^ /index.php; # For Drupal >= 7
+    }
+
+    # Don't allow direct access to PHP files in the vendor directory.
+    location ~ /vendor/.*\.php$ {
+        deny all;
+        return 404;
+    }
+
+    # Protect files and directories from prying eyes.
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|composer\.(lock|json)$|web\.config$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+        deny all;
+        return 404;
+    }
+
+    # In Drupal 8, we must also match new paths where the '.php' appears in
+    # the middle, such as update.php/selection. The rule we use is strict,
+    # and only allows this pattern with the update.php front controller.
+    # This allows legacy path aliases in the form of
+    # blog/index.php/legacy-path to continue to route to Drupal nodes. If
+    # you do not have any paths like that, then you might prefer to use a
+    # laxer rule, such as:
+    #   location ~ \.php(/|$) {
+    # The laxer rule will continue to work if Drupal uses this new URL
+    # pattern with front controllers other than update.php in a future
+    # release.
+    location ~ \.php(/|$) {
+        add_header X-Robots-Tag "${X_ROBOTS_TAG}" always;
+
+        set $access_denied ${LIMITED_BETA_MODE};
+
+        if ($request_uri ~ /form/feedback-form) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /cookies) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /user) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /visit-us) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /csearch) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /08b5d5dc-f2de-4c78-86a7-d3ea80037430) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /node) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /media) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /core) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /modules) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /themes) {
+            set $access_denied 0;
+        }
+        if ($http_cookie ~* "SESS" ) {
+            set $access_denied 0;
+        }
+        if ($access_denied) {
+            return 302 https://www.essex.gov.uk/;
         }
 
-        location = /robots.txt {
-            allow all;
-            log_not_found off;
-            access_log off;
+        # Override host for health endpoint
+        if ($uri = "/index.php/health")  {
+            set $customhost drupal;
         }
+        fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param HTTP_HOST $customhost;
+        # make drupal understand clients were talking https to the loadbalancer
+        fastcgi_param HTTPS on;
+        fastcgi_param HTTP_SCHEME https;
+        fastcgi_intercept_errors on;
+        # changed from drupal-fpm to localhost for azure containers
+        fastcgi_pass localhost:9000;
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+    }
 
-        # Very rarely should these ever be accessed outside of your lan
-        location ~* \.(txt|log)$ {
-            allow 192.168.0.0/16;
-            deny all;
-        }
+    # Scripts/styles/images
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        add_header X-Robots-Tag "${X_ROBOTS_TAG}" always;
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
+    }
 
-        location ~ \..*/.*\.php$ {
-            return 403;
-        }
+    # Documents
+    location ~* \.(pdf|(xls|doc|pp[st])[xm]?|txt|rtf|csv|key|7z|rar|gz|zip)$ {
+        add_header X-Robots-Tag "noindex" always;
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
+    }
 
-        location ~ ^/sites/.*/private/ {
-            return 403;
-        }
+    # Fighting with Styles? This little gem is amazing.
+    # location ~ ^/sites/.*/files/imagecache/ { # For Drupal <= 6
+    location ~ ^/sites/.*/files/styles/ { # For Drupal >= 7
+        try_files $uri @rewrite;
+    }
 
-        # Block access to scripts in site files directory
-        location ~ ^/sites/[^/]+/files/.*\.php$ {
-            deny all;
-        }
-
-        # Allow "Well-Known URIs" as per RFC 5785
-        location ~* ^/.well-known/ {
-            allow all;
-        }
-
-        # Block access to "hidden" files and directories whose names begin with a
-        # period. This includes directories used by version control systems such
-        # as Subversion or Git to store control files.
-        location ~ (^|/)\. {
-            return 403;
-        }
-
-        location / {
-            # try_files $uri @rewrite; # For Drupal <= 6
-            try_files $uri /index.php?$query_string; # For Drupal >= 7
-        }
-
-        location @rewrite {
-            #rewrite ^/(.*)$ /index.php?q=$1; # For Drupal <= 6
-            rewrite ^ /index.php; # For Drupal >= 7
-        }
-
-        # Don't allow direct access to PHP files in the vendor directory.
-        location ~ /vendor/.*\.php$ {
-            deny all;
-            return 404;
-        }
-
-        # Protect files and directories from prying eyes.
-        location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|composer\.(lock|json)$|web\.config$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
-            deny all;
-            return 404;
-        }
-
-        # Determine HTTP host to use based on forwarding headers
-        set $customhost $http_host;
-        if ($http_x_forwarded_host != '') {
-            set $customhost $http_x_forwarded_host;
-        }
-        if ($http_x_original_host != '') {
-            set $customhost $http_x_original_host;
-        }
-
-        # In Drupal 8, we must also match new paths where the '.php' appears in
-        # the middle, such as update.php/selection. The rule we use is strict,
-        # and only allows this pattern with the update.php front controller.
-        # This allows legacy path aliases in the form of
-        # blog/index.php/legacy-path to continue to route to Drupal nodes. If
-        # you do not have any paths like that, then you might prefer to use a
-        # laxer rule, such as:
-        #   location ~ \.php(/|$) {
-        # The laxer rule will continue to work if Drupal uses this new URL
-        # pattern with front controllers other than update.php in a future
-        # release.
-        location ~ \.php(/|$) {
-            # If we're outside of govuk then request no indexing, on the assumption that this is a non-production environment
-            if ($customhost !~* ".*\.gov\.uk") {
-                add_header X-Robots-Tag "noindex, follow" always;
-            }
-
-            # Override host for health endpoint
-            if ($uri = "/index.php/health")  {
-                set $customhost drupal;
-            }
-            fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
-            include fastcgi_params;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param PATH_INFO $fastcgi_path_info;
-            fastcgi_param HTTP_HOST $customhost;
-            # make drupal understand clients were talking https to the loadbalancer
-            fastcgi_param HTTPS on;
-            fastcgi_param HTTP_SCHEME https;
-            fastcgi_intercept_errors on;
-            # changed from drupal-fpm to localhost for azure containers
-            fastcgi_pass localhost:9000;
-            fastcgi_buffers 16 32k;
-            fastcgi_buffer_size 64k;
-            fastcgi_busy_buffers_size 64k;
-        }
-
-        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-            try_files $uri @rewrite;
-            expires max;
-            log_not_found off;
-        }
-
-        # Fighting with Styles? This little gem is amazing.
-        # location ~ ^/sites/.*/files/imagecache/ { # For Drupal <= 6
-        location ~ ^/sites/.*/files/styles/ { # For Drupal >= 7
-            try_files $uri @rewrite;
-        }
-
-        # Handle private files through Drupal. Private file's path can come
-        # with a language prefix.
-        location ~ ^(/[a-z\-]+)?/system/files/ { # For Drupal >= 7
-            try_files $uri /index.php?$query_string;
-        }
+    # Handle private files through Drupal. Private file's path can come
+    # with a language prefix.
+    location ~ ^(/[a-z\-]+)?/system/files/ { # For Drupal >= 7
+        try_files $uri /index.php?$query_string;
     }
 }


### PR DESCRIPTION
Repeat PR due to forced update on branch.

This realigns the intranet nginx config with the one from the public site, which removes the conditional noindex implementation and replaces it with the environment variable-based one.

By aligning these, it also:

* Adds limited beta mode (albeit disabled) and sets the intranet healthcheck url
* Retains the fastcgi changes in PR #257 (ECCI-487)
* Adds canonical url environment variable support, which will be needed for go-live
* Allows later versions of the official nginx image to be used in builds