### PR TITLE
ECCI-494: Increase PHP memory limit

### DIFF
--- a/Dockerfile-drupal
+++ b/Dockerfile-drupal
@@ -94,7 +94,7 @@ RUN sed -i 's;listen = /run/php/php8.1-fpm.sock;listen = 9000;' /etc/php/8.1/fpm
 RUN echo "clear_env = no" >> /etc/php/8.1/fpm/pool.d/www.conf
 RUN echo 'extension="memcached.so"' >> /etc/php/8.1/fpm/conf.d/20-memcached.ini
 RUN sed -i 's;expose_php = on;expose_php = off;' /etc/php/8.1/fpm/php.ini && mkdir -p /run/php
-RUN sed -i 's;memory_limit = 128M;memory_limit = 384M;' /etc/php/8.1/fpm/php.ini
+RUN sed -i 's;memory_limit = 128M;memory_limit = 512M;' /etc/php/8.1/fpm/php.ini
 RUN sed -i 's;upload_max_filesize = 2M;upload_max_filesize = 128M;' /etc/php/8.1/fpm/php.ini
 RUN sed -i 's;post_max_size = 8M;post_max_size = 128M;' /etc/php/8.1/fpm/php.ini
 


### PR DESCRIPTION
Some pages are hitting a PHP memory limit, despite there being plenty of free memory available. This increases the fpm limit to 512mb.