### PR TITLE
ECCI-488: Restricted content re-enabled on add news_article/newsroom forms.

### DIFF
--- a/modules/custom/localgov_restricted_content/localgov_restricted_content.module
+++ b/modules/custom/localgov_restricted_content/localgov_restricted_content.module
@@ -59,7 +59,9 @@ function localgov_restricted_content_form_node_form_alter(&$form, FormStateInter
   // form.
   if (RESTRICTED_CONTENT_FORM_FLAG) {
     switch ($form_id) {
+      case 'node_localgov_news_article_form':
       case 'node_localgov_news_article_edit_form':
+      case 'node_localgov_newsroom_form':
       case 'node_localgov_newsroom_edit_form':
         break;
 


### PR DESCRIPTION
While testing on dev, I noticed that this worked properly on the edit forms for `news_articles` and `newsrooms` content types, but not when creating new content. This addresses that.