### PR TITLE
ECCI-494: Fix memory error caused by a node being its own parent

### DIFF
--- a/modules/custom/localgov_restricted_content/src/RestrictedContent.php
+++ b/modules/custom/localgov_restricted_content/src/RestrictedContent.php
@@ -35,7 +35,7 @@ class RestrictedContent implements RestrictedContentInterface {
           if ($parent->{$this::RESTRICTED_CONTENT_FIELD}->value) {
             return TRUE;
           }
-          if ($entity->id() == $parent->id()) {
+          if ($entity->id() === $parent->id()) {
             // There's no guarantee that the entity isn't its own grandparent, but
             // abort in the simple case that it's its own parent.
             // TODO: A more complex check is needed for the non-trivial case.

--- a/modules/custom/localgov_restricted_content/src/RestrictedContent.php
+++ b/modules/custom/localgov_restricted_content/src/RestrictedContent.php
@@ -35,6 +35,12 @@ class RestrictedContent implements RestrictedContentInterface {
           if ($parent->{$this::RESTRICTED_CONTENT_FIELD}->value) {
             return TRUE;
           }
+          if ($entity->id() == $parent->id()) {
+            // There's no guarantee that the entity isn't its own grandparent, but
+            // abort in the simple case that it's its own parent.
+            // TODO: A more complex check is needed for the non-trivial case.
+            return TRUE;
+          }
           return $this->isAncestorRestricted($parent);
         }
       }

--- a/modules/custom/localgov_restricted_content/src/RestrictedContent.php
+++ b/modules/custom/localgov_restricted_content/src/RestrictedContent.php
@@ -36,8 +36,8 @@ class RestrictedContent implements RestrictedContentInterface {
             return TRUE;
           }
           if ($entity->id() === $parent->id()) {
-            // There's no guarantee that the entity isn't its own grandparent, but
-            // abort in the simple case that it's its own parent.
+            // There's no guarantee that the entity isn't its own grandparent,
+            // but abort in the simple case that it's its own parent.
             // TODO: A more complex check is needed for the non-trivial case.
             return TRUE;
           }


### PR DESCRIPTION
This amends the `isAncestorRestricted` method of `localgov_restricted_content` to detect cases where a node has been set as its direct parent, and breaks the parent-recursion chain by restricting the content. It won't detect cases where there's a cycle of length > 1, but this allows editing of a page on the intranet where this was already set.