### PR TITLE
ECCI-464: Page components are at the bottom of the newsroom now.

### DIFF
--- a/config/default/core.entity_view_display.node.localgov_newsroom.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_newsroom.default.yml
@@ -22,18 +22,13 @@ targetEntityType: node
 bundle: localgov_newsroom
 mode: default
 content:
-  content_moderation_control:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 0
-    region: content
   field_content_owner:
     type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
-    weight: 7
+    weight: 6
     region: content
   field_content_sme:
     type: entity_reference_label
@@ -41,27 +36,27 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 8
+    weight: 7
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 6
+    weight: 4
     region: content
   localgov_news_facets:
     settings: {  }
     third_party_settings: {  }
-    weight: 5
+    weight: 3
     region: content
   localgov_news_search:
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 2
     region: content
   localgov_newsroom_all_view:
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   localgov_newsroom_featured:
     type: entity_reference_entity_view
@@ -72,7 +67,7 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-    weight: 1
+    weight: 0
     region: content
   localgov_page_components:
     type: entity_reference_entity_view
@@ -83,9 +78,10 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-    weight: 3
+    weight: 5
     region: content
 hidden:
+  content_moderation_control: true
   entitygroupfield: true
   localgov_restricted_content: true
   restricted_content_sign_in: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.default.yml
@@ -22,11 +22,6 @@ targetEntityType: node
 bundle: localgov_subsites_overview
 mode: default
 content:
-  content_moderation_control:
-    settings: {  }
-    third_party_settings: {  }
-    weight: -20
-    region: content
   field_content_owner:
     type: entity_reference_label
     label: above
@@ -53,6 +48,7 @@ content:
     weight: 0
     region: content
 hidden:
+  content_moderation_control: true
   entitygroupfield: true
   links: true
   localgov_restricted_content: true

--- a/themes/custom/essex/templates/content/node--localgov-newsroom--full.html.twig
+++ b/themes/custom/essex/templates/content/node--localgov-newsroom--full.html.twig
@@ -1,0 +1,139 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+
+{%
+  set classes = [
+    'newsroom',
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+
+{% if not localgov_base_remove_css %}
+  {{ attach_library('localgov_base/sidebar') }}
+  {{ attach_library('localgov_base/news') }}
+{% endif %}
+
+<article{{ attributes.addClass(classes).removeAttribute('role') }}>
+  <div class="lgd-container padding-horizontal">
+
+    {{ title_prefix }}
+    {{ title_suffix }}
+
+    {% if display_submitted %}
+      <footer class="node__meta">
+        {{ author_picture }}
+        <div{{ author_attributes.addClass('node__submitted') }}>
+          {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
+          {{ metadata }}
+        </div>
+      </footer>
+    {% endif %}
+
+    <div{{ content_attributes.addClass('newsroom__content', 'node__content') }}>
+
+      {{ content|without('localgov_news_search', 'localgov_news_facets', 'localgov_newsroom_all_view',
+        'localgov_page_components', 'field_content_owner', 'field_content_sme') }}
+
+      {#
+        Render the search, facets, etc here, followed by the news items
+      #}
+      <div class="lgd-row">
+        <aside class="lgd-row__one-third">
+          <div class="newsroom__sidebar">
+            {{ content.localgov_news_search }}
+            {{ content.localgov_news_facets }}
+          </div>
+        </aside>
+        <div class="lgd-row__two-thirds">
+          {{ content.localgov_newsroom_all_view }}
+        </div>
+      </div>
+
+      {#
+        Render the page components followed by the owner and SME fields
+      #}
+      {% if content.localgov_page_components %}
+        <div>
+          {{ content.localgov_page_components }}
+        </div>
+      {% endif %}
+
+    </div>
+  </div>
+
+</article>

--- a/themes/custom/essex/templates/field/field--paragraphs-library-item--label--paragraphs-library-item.html.twig
+++ b/themes/custom/essex/templates/field/field--paragraphs-library-item--label--paragraphs-library-item.html.twig
@@ -1,0 +1,83 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+  'field',
+  'field--name-' ~ field_name|clean_class,
+  'field--type-' ~ field_type|clean_class,
+  'field--label-' ~ label_display,
+  label_display == 'inline' ? 'clearfix',
+]
+%}
+{%
+  set title_classes = [
+  'field__label',
+  label_display == 'visually_hidden' ? 'visually-hidden',
+]
+%}
+
+{% if label_display != 'hidden' %}
+  {% if label_hidden %}
+    {% if multiple %}
+      <div{{ attributes.addClass(classes, 'field__items') }}>
+        {% for item in items %}
+          <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+        {% endfor %}
+      </div>
+    {% else %}
+      {% for item in items %}
+        <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+    {% endif %}
+  {% else %}
+    <div{{ attributes.addClass(classes) }}>
+      <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+      {% if multiple %}
+      <div class="field__items">
+        {% endif %}
+        {% for item in items %}
+          <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+        {% endfor %}
+        {% if multiple %}
+      </div>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
## Page component **will** appear at the bottom of the page
- Also, the labels for the page_components don't appear if choose to be hidden - this needs to be examine in testing on other pages which have page_components to ensure no regressions have been introduced.
- Two content types have had the `content_modertation_control` field changed back to hidden
# This PR has been tested in the following browsers
- [x] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default