### PR TITLE
ECCI-516: Spacing between News Article body text and Related News block too small

### DIFF
--- a/themes/custom/essex/css/news.css
+++ b/themes/custom/essex/css/news.css
@@ -296,8 +296,16 @@ div:has(.featured-teaser),
     .paragraph--type--news-1-4 .featured-news__card .card-content {
         height: 100%;
     }
+
+    .news-article__related-title {
+        margin-top: var(--spacing-mega);
+    }
 }
 
 a>i {
     margin-left: 0.2rem;
+}
+
+.field--name-field-media-image {
+    margin-bottom: var(--spacing-large)
 }

--- a/themes/custom/essex/css/news.css
+++ b/themes/custom/essex/css/news.css
@@ -187,6 +187,14 @@ div:has(.featured-teaser),
     flex-direction: column;
 }
 
+.featured-news__card article .card-content p,
+.news-card article .card-content p {
+    --font-size: clamp(1rem, 0.85rem + 0.5vw, 1.125rem);
+    --line-height: 1.5;
+    font-size: var(--font-size);
+    line-height: var(--line-height);
+}
+
 .featured-news__card article .card-content .node__content,
 .news-card article .card-content .node__content {
     height: 100%;

--- a/themes/custom/essex/css/overrides.css
+++ b/themes/custom/essex/css/overrides.css
@@ -1439,10 +1439,3 @@ footer .lgd-footer__footer a {
 .lgd-region--content .paragraph--type--localgov-contact a {
   word-break: break-word;
 }
-
-p {
-  --font-size: clamp(1rem, 0.85rem + 0.5vw, 1.125rem);
-  --line-height: 1.5;
-  font-size: var(--font-size);
-  line-height: var(--line-height);
-}

--- a/themes/custom/essex/css/overrides.css
+++ b/themes/custom/essex/css/overrides.css
@@ -1439,3 +1439,10 @@ footer .lgd-footer__footer a {
 .lgd-region--content .paragraph--type--localgov-contact a {
   word-break: break-word;
 }
+
+p {
+  --font-size: clamp(1rem, 0.85rem + 0.5vw, 1.125rem);
+  --line-height: 1.5;
+  font-size: var(--font-size);
+  line-height: var(--line-height);
+}


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [X] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
