### PR TITLE
ECCI-517: FA button added to CKEditor.

### DIFF
--- a/config/default/editor.editor.wysiwyg.yml
+++ b/config/default/editor.editor.wysiwyg.yml
@@ -20,6 +20,7 @@ settings:
             - Format
             - Styles
             - CreateDiv
+            - DrupalFontAwesome
         -
           name: Edit
           items:
@@ -53,11 +54,11 @@ settings:
           items:
             - Table
   plugins:
+    stylescombo:
+      styles: "mark|Highlightly\r\na.external-link|External link\r\na.pdf-link|PDF link\r\na.button.button-start.col-sm-6.mt-3|Start button\r\np.alert.alert-info|Alert info\r\np.inset|Inset text\r\ndiv.alert.alert-info|Container - Alert info\r\nb|Semi-bold\r\ndiv.inset|Inset  text"
     drupallink:
       linkit_enabled: true
       linkit_profile: default
-    stylescombo:
-      styles: "mark|Highlightly\r\na.external-link|External link\r\na.pdf-link|PDF link\r\na.button.button-start.col-sm-6.mt-3|Start button\r\np.alert.alert-info|Alert info\r\np.inset|Inset text\r\ndiv.alert.alert-info|Container - Alert info\r\nb|Semi-bold\r\ndiv.inset|Inset  text"
 image_upload:
   status: false
   scheme: public


### PR DESCRIPTION
## Improves the chevron adding experience
## By adding the FA flag icon to the CKEditor toolbar:
- The right chevron will appear in the WYSIWYG selector
- Instructions based on the [Drupal docs](https://www.drupal.org/docs/contributed-modules/font-awesome-icons/using-font-awesome-icons-in-ckeditor)

## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)

![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/158008/3a803911-2490-46a2-9718-4fd60d038e3d)

Although you can choose any of the FA icons available when editing, you **must** add the `chevron-right` to get any icon whatsoever:

![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/158008/255bc2cb-69c4-4030-98e4-ef3508d1aae9)


## This PR has been tested in the following browsers
- [x] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
