### PR TITLE
ECCI-484: WebP files can now be uploaded.

### DIFF
--- a/config/default/field.field.media.image.field_media_image.yml
+++ b/config/default/field.field.media.image.field_media_image.yml
@@ -23,21 +23,21 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg webp'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
   alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false
-  max_resolution: ''
-  min_resolution: ''
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null
     height: null
-  file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  handler: 'default:file'
-  handler_settings: {  }
 field_type: image


### PR DESCRIPTION
## Allow one more file type to be uploaded: WebP
## Implementation
- No conversions to WebP are done, just allows them to be added and used
- Imagemagick and do the cropping as necessary
## This PR has been tested in the following browsers
- [x] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
