### PR TITLE
ECCI-519: Robots.txt to allow Cludo.

### DIFF
--- a/assets/composer/robots.txt
+++ b/assets/composer/robots.txt
@@ -1,2 +1,5 @@
+User-agent: Cludo
+Disallow:
+
 User-agent: *
 Disallow: /


### PR DESCRIPTION
## Turns out Cludo _does_ respect the `robots.txt` file
