### PR TITLE
ECCI-521: Set Automatic Cron to run every 900 seconds

### DIFF
--- a/config/default/automated_cron.settings.yml
+++ b/config/default/automated_cron.settings.yml
@@ -1,3 +1,3 @@
 _core:
   default_config_hash: fUksROt4FfkAU9BV4hV2XvhTBSS2nTNrZS4U7S-tKrs
-interval: 0
+interval: 900


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
ECCI-439 stopped Cron running automatically. Set it to run every 900 seconds (15 minutes.)

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
