### PR TITLE
ECCI-442: Downgrade Dynamic Entity Reference module to fix SQL error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "drupal/core-project-message": "^10",
         "drupal/core-recommended": "^10.1",
         "drupal/devel": "^5.1",
-        "drupal/dynamic_entity_reference": "^4",
+        "drupal/dynamic_entity_reference": "^3.1",
         "drupal/entitygroupfield": "^2",
         "drupal/eu_cookie_compliance": "^1.24",
         "drupal/eu_cookie_compliance_gtm": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b1e69bfb14ee4213b9dc07918dfcdc6",
+    "content-hash": "a2d5e20c064b11e44d2ebe62210d3f5b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3747,17 +3747,17 @@
         },
         {
             "name": "drupal/dynamic_entity_reference",
-            "version": "4.0.0-alpha3",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/dynamic_entity_reference.git",
-                "reference": "4.0.0-alpha3"
+                "reference": "3.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/dynamic_entity_reference-4.0.0-alpha3.zip",
-                "reference": "4.0.0-alpha3",
-                "shasum": "8f2399c134bc8f0112eefbe2b900cbcf90c9ce08"
+                "url": "https://ftp.drupal.org/files/projects/dynamic_entity_reference-3.1.0.zip",
+                "reference": "3.1.0",
+                "shasum": "4672b535acc326320f012033db94b5c0e379362c"
             },
             "require": {
                 "drupal/core": "^10 || ^11",
@@ -3771,11 +3771,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.0.0-alpha3",
-                    "datestamp": "1688838696",
+                    "version": "3.1.0",
+                    "datestamp": "1688838762",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Error when running `drush deploy` when deploying to Dev:
```
SQLSTATE[HY000]: General error: 1419 You do not have the SUPER privilege and binary logging is enabled (you *might*   
  want to use the less safe log_bin_trust_function_creators variable): DROP TRIGGER IF EXISTS paragraph__field_news_cards_der_update
```
See https://www.drupal.org/project/dynamic_entity_reference/issues/3382404
There is no patch yet but one recommendation is to downgrade the module.
