### PR TITLE
Task/ecci 527 patch openid connect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "drupal/simple_sitemap": "^4.1",
         "drupal/single_content_sync": "^1.4",
         "drupal/smtp": "^1.2",
-        "drupal/stage_file_proxy": "^2.0",
+        "drupal/stage_file_proxy": "^2.1",
         "drupal/ultimate_cron": "^2.0@alpha",
         "drupal/upgrade_status": "^4.0",
         "drupal/webform": "^6.2",
@@ -163,6 +163,9 @@
             },
             "drupal/group": {
                 "Apply some custom functionality for Essex when adding members to Groups ECCI-287/ECCI-286": "patches/essex-group-membership.patch"
+            },
+            "drupal/openid_connect": {
+                "Truncate username if it is greater than 60 characters": "https://www.drupal.org/files/issues/2021-12-08/data_too_long_for_column_name-%203252021-8.patch"
             },
             "localgovdrupal/localgov_paragraphs": {
                 "Added missing field which has been introduced recently.": "patches/missing_field.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03b74f9ae18878e7fc211fbfe8f49d13",
+    "content-hash": "34706cc686cdb86e0c972bf4590be693",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -19233,7 +19233,7 @@
                 "melisplatform/melis-front": "<5.0.1",
                 "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
                 "mgallegos/laravel-jqgrid": "<=1.3",
-                "microweber/microweber": "<2.0.3",
+                "microweber/microweber": "<=2.0.4",
                 "miniorange/miniorange-saml": "<1.4.3",
                 "mittwald/typo3_forum": "<1.2.1",
                 "mobiledetect/mobiledetectlib": "<2.8.32",
@@ -19311,7 +19311,7 @@
                 "phpmyfaq/phpmyfaq": "<=3.1.7",
                 "phpoffice/phpexcel": "<1.8",
                 "phpoffice/phpspreadsheet": "<1.16",
-                "phpseclib/phpseclib": "<3.0.34",
+                "phpseclib/phpseclib": "<2.0.31|>=3,<3.0.34",
                 "phpservermon/phpservermon": "<3.6",
                 "phpsysinfo/phpsysinfo": "<3.2.5",
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5,<5.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b63fb3126f1ce6fbf63555729cafab40",
+    "content-hash": "03b74f9ae18878e7fc211fbfe8f49d13",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## Patch to resolve usernames greater than 60 characters.
## Implementation decisions
- A quick solution to update the `users_field_data.name` to be greater than `varchar(60)` was rejected, because although not hugely risky, that's not the way to do Drupal development.
- Looked at using `hook_openid_connect_userinfo_alter()` in the [OpenID Connect Azure B2C](https://www.drupal.org/project/openid_connect_azure_b2c) module, but @Polynya found in the OpenIDConnect issue queue that it is a more general problem and that a patch exists, and works locally.
- The only way we can properly know this works is if we get someone with an extraordinarily large username from Essex to login, as Nomensan's usernames contain only their names and not their title as well
