### PR TITLE
ECCI-423: Apply restricted content to all non-news content types

### DIFF
--- a/config/default/block.block.guidecontents.yml
+++ b/config/default/block.block.guidecontents.yml
@@ -3,7 +3,9 @@ langcode: en
 status: true
 dependencies:
   module:
+    - block_classes
     - localgov_guides
+    - localgov_restricted_content
     - node
   theme:
     - essex
@@ -27,3 +29,10 @@ visibility:
     bundles:
       localgov_guides_overview: localgov_guides_overview
       localgov_guides_page: localgov_guides_page
+  restricted_content:
+    id: restricted_content
+    enabled: 1
+    negate: 0
+    context_mapping:
+      node: '@node.node_route_context:node'
+      user: '@user.current_user_context:current_user'

--- a/config/default/block.block.guidesprevnextblock.yml
+++ b/config/default/block.block.guidesprevnextblock.yml
@@ -3,7 +3,9 @@ langcode: en
 status: true
 dependencies:
   module:
+    - block_classes
     - localgov_guides
+    - localgov_restricted_content
   theme:
     - essex
 id: guidesprevnextblock
@@ -17,4 +19,12 @@ settings:
   label: 'Guides prev next block'
   label_display: '0'
   provider: localgov_guides
-visibility: {  }
+  show_title: false
+visibility:
+  restricted_content:
+    id: restricted_content
+    enabled: 1
+    negate: 0
+    context_mapping:
+      node: '@node.node_route_context:node'
+      user: '@user.current_user_context:current_user'

--- a/config/default/block.block.partofstepheading.yml
+++ b/config/default/block.block.partofstepheading.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   module:
+    - block_classes
+    - localgov_restricted_content
     - localgov_step_by_step
     - node
   theme:
@@ -26,3 +28,10 @@ visibility:
       node: '@node.node_route_context:node'
     bundles:
       localgov_step_by_step_page: localgov_step_by_step_page
+  restricted_content:
+    id: restricted_content
+    enabled: 1
+    negate: 0
+    context_mapping:
+      node: '@node.node_route_context:node'
+      user: '@user.current_user_context:current_user'

--- a/config/default/block.block.subsitebanner.yml
+++ b/config/default/block.block.subsitebanner.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   module:
+    - block_classes
+    - localgov_restricted_content
     - localgov_subsites
     - node
   theme:
@@ -28,3 +30,11 @@ visibility:
       node: '@node.node_route_context:node'
     bundles:
       localgov_subsites_overview: localgov_subsites_overview
+  restricted_content:
+    id: restricted_content
+    pages: ''
+    negate: 0
+    enabled: 1
+    context_mapping:
+      node: '@node.node_route_context:node'
+      user: '@user.current_user_context:current_user'

--- a/config/default/block.block.subsitenavigation.yml
+++ b/config/default/block.block.subsitenavigation.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   module:
+    - block_classes
+    - localgov_restricted_content
     - localgov_subsites
     - node
   theme:
@@ -28,3 +30,10 @@ visibility:
       node: '@node.node_route_context:node'
     bundles:
       localgov_subsites_overview: localgov_subsites_overview
+  restricted_content:
+    id: restricted_content
+    enabled: 1
+    negate: 0
+    context_mapping:
+      node: '@node.node_route_context:node'
+      user: '@user.current_user_context:current_user'

--- a/config/default/block.block.views_block__localgov_step_by_step_navigation_prev_next.yml
+++ b/config/default/block.block.views_block__localgov_step_by_step_navigation_prev_next.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - views.view.localgov_step_by_step_navigation
   module:
+    - block_classes
+    - localgov_restricted_content
     - views
   theme:
     - essex
@@ -23,4 +25,11 @@ settings:
     nid: '@node.node_route_context:node'
   views_label: ''
   items_per_page: none
-visibility: {  }
+visibility:
+  restricted_content:
+    id: restricted_content
+    enabled: 1
+    negate: 0
+    context_mapping:
+      node: '@node.node_route_context:node'
+      user: '@user.current_user_context:current_user'

--- a/config/default/block.block.views_block__localgov_step_by_step_navigation_steps.yml
+++ b/config/default/block.block.views_block__localgov_step_by_step_navigation_steps.yml
@@ -6,6 +6,7 @@ dependencies:
     - views.view.localgov_step_by_step_navigation
   module:
     - block_classes
+    - localgov_restricted_content
     - node
     - views
   theme:
@@ -35,3 +36,10 @@ visibility:
       node: '@node.node_route_context:node'
     bundles:
       localgov_step_by_step_page: localgov_step_by_step_page
+  restricted_content:
+    id: restricted_content
+    enabled: 1
+    negate: 0
+    context_mapping:
+      node: '@node.node_route_context:node'
+      user: '@user.current_user_context:current_user'

--- a/config/default/block.block.views_block__localgov_step_by_step_navigation_steps_for_overview.yml
+++ b/config/default/block.block.views_block__localgov_step_by_step_navigation_steps_for_overview.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - views.view.localgov_step_by_step_navigation
   module:
+    - block_classes
+    - localgov_restricted_content
     - node
     - views
   theme:
@@ -32,3 +34,10 @@ visibility:
       node: '@node.node_route_context:node'
     bundles:
       localgov_step_by_step_overview: localgov_step_by_step_overview
+  restricted_content:
+    id: restricted_content
+    enabled: 1
+    negate: 0
+    context_mapping:
+      node: '@node.node_route_context:node'
+      user: '@user.current_user_context:current_user'

--- a/modules/custom/localgov_restricted_content/localgov_restricted_content.services.yml
+++ b/modules/custom/localgov_restricted_content/localgov_restricted_content.services.yml
@@ -1,3 +1,12 @@
 services:
   localgov_restricted_content.restricted_content:
     class: Drupal\localgov_restricted_content\RestrictedContent
+
+  # Alter page header.
+  localgov_restricted_content.event_page_header:
+    class: Drupal\localgov_restricted_content\EventSubscriber\PageHeaderSubscriber
+    arguments:
+      - '@current_user'
+      - '@localgov_restricted_content.restricted_content'
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/custom/localgov_restricted_content/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/modules/custom/localgov_restricted_content/src/EventSubscriber/PageHeaderSubscriber.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\localgov_restricted_content\EventSubscriber;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\localgov_core\Event\PageHeaderDisplayEvent;
+use Drupal\localgov_restricted_content\RestrictedContentInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Page header event to hide 'lede' on restricted content.
+ *
+ * @package Drupal\localgov_restricted_content\EventSubscriber
+ */
+class PageHeaderSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Account.
+   * @param \Drupal\localgov_restricted_content\RestrictedContentInterface $restrictedContent
+   *   The restricted content service.
+   */
+  public function __construct(
+    protected AccountInterface $account,
+    protected RestrictedContentInterface $restrictedContent) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      PageHeaderDisplayEvent::EVENT_NAME => ['setPageHeader', 0],
+    ];
+  }
+
+  /**
+   * Set page title and lede.
+   */
+  public function setPageHeader(PageHeaderDisplayEvent $event) {
+
+    $node = $event->getEntity();
+
+    if (!$node instanceof NodeInterface) {
+      return;
+    }
+
+    if (
+      $this->restrictedContent->isRestricted($node) and
+      $this->account->isAnonymous()
+    ) {
+      $event->setLede('');
+    }
+  }
+
+}

--- a/modules/custom/localgov_restricted_content/src/Plugin/Condition/RestrictedContent.php
+++ b/modules/custom/localgov_restricted_content/src/Plugin/Condition/RestrictedContent.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\localgov_restricted_content\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'Restricted Content' condition.
+ *
+ * @Condition(
+ *   id = "restricted_content",
+ *   label = @Translation("Restricted Content"),
+ *   context_definitions = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("Current node"), required = TRUE),
+ *     "user" = @ContextDefinition("entity:user", label = @Translation("User"))
+ *   }
+ * )
+ */
+class RestrictedContent extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Restricted Content service.
+   *
+   * @var \Drupal\localgov_restricted_content\RestrictedContentInterface
+   */
+  protected $restrictedContent;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->restrictedContent = $container->get('localgov_restricted_content.restricted_content');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('@state true if user is not logged in and the current page is restricted content.', [
+      '@state' => empty($this->configuration['negate']) ? $this->t('Return') : $this->t('Do not return'),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['enabled' => FALSE] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enabled'),
+      '#default_value' => $this->configuration['enabled'],
+      '#description' => $this->t('Check if user can view restricted content.'),
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['enabled'] = $form_state->getValue('enabled');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEnabled() {
+    return !empty($this->configuration['enabled']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    if (!$this->isEnabled()) {
+      return TRUE;
+    }
+    /** @var \Drupal\user\UserInterface $user */
+    $user = $this->getContextValue('user');
+    if ($user instanceof UserInterface and $user->isAuthenticated()) {
+      return TRUE;
+    }
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $this->getContextValue('node');
+    return (
+      $node instanceof NodeInterface and
+      !$this->restrictedContent->isRestricted($node)
+    );
+  }
+
+}

--- a/modules/custom/localgov_restricted_content/src/RestrictedContent.php
+++ b/modules/custom/localgov_restricted_content/src/RestrictedContent.php
@@ -38,7 +38,7 @@ class RestrictedContent implements RestrictedContentInterface {
           if ($entity->id() === $parent->id()) {
             // There's no guarantee that the entity isn't its own grandparent,
             // but abort in the simple case that it's its own parent.
-            // TODO: A more complex check is needed for the non-trivial case.
+            // @todo A more complex check is needed for the non-trivial case.
             return TRUE;
           }
           return $this->isAncestorRestricted($parent);

--- a/themes/custom/essex/templates/content/node--full-anonymous.html.twig
+++ b/themes/custom/essex/templates/content/node--full-anonymous.html.twig
@@ -120,37 +120,15 @@
 <article{{ attributes.addClass(classes).removeAttribute('role') }}>
 
   <div class="lgd-container padding-horizontal">
-    {{ title_prefix }}
-    {% if label and not page %}
-      <h2{{ title_attributes }}>
-        <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-      </h2>
-    {% endif %}
-    {{ title_suffix }}  
-
-    {% if display_submitted %}
-      <footer class="node__meta">
-        {{ author_picture }}
-        <div{{ author_attributes.addClass('node__submitted') }}>
-          {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
-          {{ metadata }}
-        </div>
-      </footer>
-    {% endif %} 
 
     {% if content_type in restricted_width_content_types %}
       <div class="node__restricted-width-section">
     {% endif %} 
 
       <div{{ content_attributes.addClass(content_type|clean_class ~ '__content', 'node__content') }}>
-        {{ content|without('localgov_subsites_content') }}
+        {{ content }}
       </div>
   </div>
-
-  {% if node.localgov_subsites_content.value %}
-    {{ content.localgov_subsites_content }}
-  {% endif %}
-  
 
   {% if content_type in restricted_width_content_types %}
     </div>


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Anonymous users should only see the title, image and sign-in message on pages marked as restricted content. Already implemented for news.

- Create Restricted Content condition
- Add condition to blocks that should be hidden on restricted content pages for anonymous users
- Hide summary text in page header block on restricted content
- Cleanup node--full-anonymous template so it displays any available fields. In practice, the anonymous display mode only has the restricted content message


## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
Same as already delivered for news articles and newsrooms
- Any particular problem areas?
Many pages have blocks displayed so a new condition was required to hide them if the user isn't logged in and the page is restricted.
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
A subsite overview
![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/56226/cd1abd7f-c98a-46d3-99dd-f7a8d490bbc1)

Directory promotion
![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/56226/8e2feb99-75a6-40df-8a49-e41ea0c28205)


## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
