### PR TITLE
Bugfix/ecci 523 teaser2 height

### DIFF
--- a/themes/custom/essex/css/news.css
+++ b/themes/custom/essex/css/news.css
@@ -370,7 +370,15 @@ div:has(.featured-teaser),
     object-fit: cover;
 }
 
-
+.paragraph--type--localgov-newsroom-teaser2 {
+  height: 100%;
+  .news-card {
+    height: 100%;
+  }
+  article {
+    min-width: 0;
+  }
+}
 
 p:has(a+i) {
     display: flex;

--- a/themes/custom/essex/templates/paragraphs/paragraph--localgov-newsroom-teaser.html.twig
+++ b/themes/custom/essex/templates/paragraphs/paragraph--localgov-newsroom-teaser.html.twig
@@ -75,6 +75,6 @@
               {{ content.localgov_newsroom_teaser_summary }}
             </div>
         {% endif %}
-    <div>
+    </div>
 
 </article>


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/56226/ca0e734b-e9ee-45cb-9091-b2314e691d5f)

- Make all newsroom teaser2 components in a 3 column layout the same height
- Fix width at tablet size when there are long words.
- Close div in template

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
This helped with the width https://codepen.io/lehollandaisvolant/pen/MvOYxp
- Why have you taken the approach?
The CSS is targeted at teaser2 to avoid changing anything else 
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
