### PR TITLE
ECCI-442: Hide title for Guide Contents block.

### DIFF
--- a/config/default/block.block.ecc_theme_intranet_guidecontents.yml
+++ b/config/default/block.block.ecc_theme_intranet_guidecontents.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - block_classes
     - localgov_guides
     - localgov_restricted_content
     - node
@@ -17,7 +18,7 @@ plugin: localgov_guides_contents
 settings:
   id: localgov_guides_contents
   label: 'Guide contents'
-  label_display: visible
+  label_display: '0'
   provider: localgov_guides
 visibility:
   'entity_bundle:node':


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Hide title of the block "Guide Contents"

![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/56226/4efe8124-fa62-4655-89ce-c28622760fc3)

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
