### PR TITLE
Change GTM permission to prevent error.

### DIFF
--- a/config/default/user.role.analytics.yml
+++ b/config/default/user.role.analytics.yml
@@ -17,6 +17,6 @@ permissions:
   - 'access toolbar'
   - 'administer eu cookie compliance categories'
   - 'administer eu cookie compliance popup'
-  - 'administer google_tag_container'
+  - 'administer google tag manager'
   - 'administer meta tags'
   - 'view the administration theme'


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Drupal 10 throws an error when it finds that role has a permission that doesn't exist. This one must have occurred when the version of Google Tag was changed.