### PR TITLE
Gitlab CI jobs to deploy straight to Prod.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -406,7 +406,7 @@ deploy-straight-to-prod:
     - az extension add --name containerapp
     - az login --service-principal -u${ARM_CLIENT_ID} -p${ARM_CLIENT_SECRET} -t${ARM_TENANT_ID}
   script:
-    - echo "Importing image from Pre-Production into Production"
+    - echo "Importing image from Development into Production"
     - az acr import --force --name acreccuksprod --source acreccuksdev.azurecr.io/intranet-nginx-drupal:${CI_COMMIT_REF_SLUG} --image intranet-nginx-drupal:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
     - az acr import --force --name acreccuksprod --source acreccuksdev.azurecr.io/intranet-nginx-drupal:${CI_COMMIT_REF_SLUG} --image intranet-nginx-drupal:latest --subscription "Essex County Council (Common)"
     - az acr import --force --name acreccuksprod --source acreccuksdev.azurecr.io/intranet-drupal-fpm:${CI_COMMIT_REF_SLUG} --image intranet-drupal-fpm:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -295,8 +295,7 @@ drush-deploy-preprod:
 deploy-to-prod:
   image: mcr.microsoft.com/azure-cli
   stage: production
-  needs:
-    - job: build-and-push-images
+  needs: ["deploy-to-preprod"]
   environment:
     name: production
     url: https://intranet.essex.gov.uk/
@@ -382,6 +381,109 @@ drush-deploy-prod:
   image: mcr.microsoft.com/azure-cli
   stage: production-postdeploy
   needs: ["deploy-to-prod"]
+  before_script:
+    - apk add socat
+    - az extension add --name containerapp
+    - az login --service-principal -u${ARM_CLIENT_ID} -p${ARM_CLIENT_SECRET} -t${ARM_TENANT_ID}
+    - az account set --subscription "Essex County Council (intranet)"
+  script:
+    - timeout 1200 socat EXEC:'az containerapp exec --command /drupal/deploy.sh --name intranet --container drupal --resource-group rg-ecc-intranet-uks-prod',pty,setsid,ctty STDIO,ignoreeof
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: manual
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: manual
+
+deploy-straight-to-prod:
+  image: mcr.microsoft.com/azure-cli
+  stage: production
+  needs:
+    - job: build-and-push-images
+  environment:
+    name: production
+    url: https://intranet.essex.gov.uk/
+  before_script:
+    - az extension add --name containerapp
+    - az login --service-principal -u${ARM_CLIENT_ID} -p${ARM_CLIENT_SECRET} -t${ARM_TENANT_ID}
+  script:
+    - echo "Importing image from Pre-Production into Production"
+    - az acr import --force --name acreccuksprod --source acreccuksdev.azurecr.io/intranet-nginx-drupal:${CI_COMMIT_REF_SLUG} --image intranet-nginx-drupal:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccuksprod --source acreccuksdev.azurecr.io/intranet-nginx-drupal:${CI_COMMIT_REF_SLUG} --image intranet-nginx-drupal:latest --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccuksprod --source acreccuksdev.azurecr.io/intranet-drupal-fpm:${CI_COMMIT_REF_SLUG} --image intranet-drupal-fpm:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccuksprod --source acreccuksdev.azurecr.io/intranet-drupal-fpm:${CI_COMMIT_REF_SLUG} --image intranet-drupal-fpm:latest --subscription "Essex County Council (Common)"
+    - echo "Creating new revision of Container App"
+    - |
+      cat > revision.yml <<EOF
+      properties:
+        template:
+          revisionSuffix: ${CI_PIPELINE_ID}
+          scale:
+            minReplicas: 1
+            maxReplicas: 3
+            rules:
+              - name: "http-rule"
+                http:
+                  metadata:
+                    concurrentRequests: 40
+          containers:
+            - image: acreccuksprod.azurecr.io/intranet-nginx-drupal:${CI_COMMIT_REF_SLUG}
+              name: nginx
+              resources:
+                cpu: 0.25
+                memory: 0.5Gi
+              volumeMounts:
+              - mountPath: /drupal/web/sites/default/files
+                volumeName: filesharevol
+              env:
+              - name: X_ROBOTS_TAG
+                value: none
+              - name: CANONICAL_HOST
+                value: intranet.essex.gov.uk
+              probes:
+              - type: liveness
+                httpGet:
+                  path: "/08b5d5dc-f2de-4c78-86a7-d3ea80037430"
+                  port: 80
+                initialDelaySeconds: 5
+                periodSeconds: 3
+            - image: acreccuksprod.azurecr.io/intranet-drupal-fpm:${CI_COMMIT_REF_SLUG}
+              name: drupal
+              resources:
+                cpu: 0.75
+                memory: 1.5Gi
+              volumeMounts:
+              - mountPath: /drupal/web/sites/default/files
+                volumeName: filesharevol
+              env:
+              - name: MYSQL_HOST
+                value: mariadb-ecc-uks-prod.mariadb.database.azure.com
+              - name: MYSQL_USER
+                value: mariadb-root
+              - name: MYSQL_DATABASE
+                value: drupal_intranet
+              - name: MYSQL_PASSWORD
+                secretRef: mysql-password
+              - name: OPENID_CONNECT_PARAMS
+                secretRef: openid-connect-params
+              probes:
+              - type: liveness
+                tcpSocket:
+                  port: 9000
+                initialDelaySeconds: 5
+                periodSeconds: 3
+      EOF
+    - az containerapp revision copy --name intranet --resource-group rg-ecc-intranet-uks-prod --yaml revision.yml --subscription "Essex County Council (intranet)"
+    - az containerapp update --name intranet --resource-group rg-ecc-intranet-uks-prod --subscription "Essex County Council (intranet)" --container-name drupal --set-env-vars "ENVIRONMENT=${ENVIRONMENT}" "FATHOM_ID=${FATHOM_ID}"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: manual
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: manual
+
+drush-deploy-straight-to-prod:
+  image: mcr.microsoft.com/azure-cli
+  stage: production-postdeploy
+  needs: ["deploy-straight-to-prod"]
   before_script:
     - apk add socat
     - az extension add --name containerapp


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)

- New jobs to deploy to Prod without going to Preprod. This require the containers to be imported from Dev.
- Revert deploy-to-prod to depend on deploy-to-preprod