### PR TITLE
LP-83: Restore robots.txt

### DIFF
--- a/assets/composer/robots.txt
+++ b/assets/composer/robots.txt
@@ -1,2 +1,5 @@
-# This robots.txt file is temporarily empty so that crawlers can discover the
-# 'X-Robots-tag: none' header on every page.
+User-agent: Cludo
+Disallow:
+
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Robots.txt content was removed temporarily so that search engines could scan the site and find the headers telling them not to index any page. Now the pages have been removed from Google, robots.txt can be restored. (It probably is unnecessary as the headers are doing their job, but is belt and braces.)

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
