### PR TITLE
LP-65: Add Hotjar to text for analytics cookies.

### DIFF
--- a/config/default/eu_cookie_compliance.cookie_category.analytics_cookies.yml
+++ b/config/default/eu_cookie_compliance.cookie_category.analytics_cookies.yml
@@ -4,6 +4,6 @@ status: true
 dependencies: {  }
 id: analytics_cookies
 label: 'Analytics cookies'
-description: 'We use Google Analytics and Hotjar cookies to measure how you use www.essex.gov.uk. The data we collect helps us improve the website.'
+description: 'We use Google Analytics and Hotjar cookies to measure how you use intranet.essex.gov.uk. The data we collect helps us improve the website.'
 checkbox_default_state: unchecked
 weight: -9

--- a/config/default/eu_cookie_compliance.cookie_category.analytics_cookies.yml
+++ b/config/default/eu_cookie_compliance.cookie_category.analytics_cookies.yml
@@ -4,6 +4,6 @@ status: true
 dependencies: {  }
 id: analytics_cookies
 label: 'Analytics cookies'
-description: 'We use Google Analytics cookies to measure how you use intranet.essex.gov.uk. The data we collect helps us improve the website.'
+description: 'We use Google Analytics and Hotjar cookies to measure how you use www.essex.gov.uk. The data we collect helps us improve the website.'
 checkbox_default_state: unchecked
 weight: -9


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Hotjar has been added through GTM so the EU Cookie Control text has to be updated.
![image](https://github.com/essexcountycouncil/essex-intranet-drupal/assets/56226/8dcecb8b-fd5b-4330-8927-c7a3131e4cd2)

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
