### PR TITLE
If no corrected on date, show published date for review/published dat…

### DIFF
--- a/config/default/views.view.published_review_dates.yml
+++ b/config/default/views.view.published_review_dates.yml
@@ -24,6 +24,83 @@ display:
     display_options:
       title: 'Published/Review Dates'
       fields:
+        published_date:
+          id: published_date
+          table: node_field_data
+          field: published_date
+          relationship: entity
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: published_date
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: just_human_date
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: just_human_date
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         corrected_date:
           id: corrected_date
           table: node_field_data
@@ -34,7 +111,7 @@ display:
           entity_type: node
           entity_field: corrected_date
           plugin_id: field
-          label: 'Last Published Date'
+          label: 'Last published date'
           exclude: false
           alter:
             alter_text: false
@@ -71,14 +148,14 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: '{{ published_date }}'
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: timestamp
           settings:
-            date_format: medium
+            date_format: just_human_date
             custom_date_format: ''
             timezone: ''
             tooltip:
@@ -90,6 +167,7 @@ display:
               past_format: '@interval ago'
               granularity: 2
               refresh: 60
+              description: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -110,7 +188,7 @@ display:
           entity_type: review_date
           entity_field: review
           plugin_id: field
-          label: 'Next Review Date'
+          label: 'Next review date'
           exclude: false
           alter:
             alter_text: false
@@ -154,7 +232,7 @@ display:
           click_sort_column: value
           type: timestamp
           settings:
-            date_format: medium
+            date_format: just_human_date
             custom_date_format: ''
             timezone: ''
             tooltip:
@@ -166,6 +244,7 @@ display:
               past_format: '@interval ago'
               granularity: 2
               refresh: 60
+              description: ''
           group_column: value
           group_columns: {  }
           group_rows: true


### PR DESCRIPTION
Adds 'no results' behaviour to the 'last published' field of the `last published, last reviewed` view, to display the `published` date. The current field shows the `corrected on` date, which is null on first publishing.
Jira: https://eccservicetransformation.atlassian.net/browse/LP-85