### PR TITLE
fix(LP-179): Empty robots.txt

### DIFF
--- a/assets/composer/robots.txt
+++ b/assets/composer/robots.txt
@@ -1,5 +1,2 @@
-User-agent: Cludo
-Disallow:
-
-User-agent: *
-Disallow: /
+# This robots.txt file is empty so that crawlers can discover the
+# 'X-Robots-tag: none' header on every page.


### PR DESCRIPTION
fix(LP-179): Empty robots.txt to allow X-Robots-Tag header to be discovered on all pages.

The Intranet home page started appearing in Google search results after the last change to robots.txt. 

We have the X-Robots-Tag on every page so bots should not be blocked from finding it by robots.txt.
![image](https://github.com/user-attachments/assets/c3203d6d-4f70-49cc-9ba8-40525d8b8c21)

## Include a summary of what this merge request involves (*)
## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
https://developers.google.com/search/docs/crawling-indexing/block-indexing

- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
