### PR TITLE
ci(): Azure-cli is no longer based on Alpine so switch apk to apt-get

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,8 +54,8 @@ generate-sbom:
     - apk add bash curl --update-cache
     - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
   script:
-    - docker pull ${DOCKER_REGISTRY}/portal-drupal-fpm${tag}
-    - syft docker:${DOCKER_REGISTRY}/portal-drupal-fpm${tag} -o json=dockerimage.sbom.json
+    - docker pull ${DOCKER_REGISTRY}/portal-intranet-fpm${tag}
+    - syft docker:${DOCKER_REGISTRY}/portal-intranet-fpm${tag} -o json=dockerimage.sbom.json
   only:
     - develop
     - /^release\//
@@ -187,7 +187,7 @@ drush-deploy-dev:
   stage: development-postdeploy
   needs: ["deploy-to-dev"]
   before_script:
-    - apk add socat
+    - apt-get install socat
     - az extension add --name containerapp
     - az login --service-principal -u${ARM_CLIENT_ID} -p${ARM_CLIENT_SECRET} -t${ARM_TENANT_ID}
     - az account set --subscription "Essex County Council (intranet)"
@@ -301,7 +301,7 @@ drush-deploy-preprod:
   stage: preproduction-postdeploy
   needs: ["deploy-to-preprod"]
   before_script:
-    - apk add socat
+    - apt-get install socat
     - az extension add --name containerapp
     - az login --service-principal -u${ARM_CLIENT_ID} -p${ARM_CLIENT_SECRET} -t${ARM_TENANT_ID}
     - az account set --subscription "Essex County Council (intranet)"
@@ -408,7 +408,7 @@ drush-deploy-prod:
   stage: production-postdeploy
   needs: ["deploy-to-prod"]
   before_script:
-    - apk add socat
+    - apt-get install socat
     - az extension add --name containerapp
     - az login --service-principal -u${ARM_CLIENT_ID} -p${ARM_CLIENT_SECRET} -t${ARM_TENANT_ID}
     - az account set --subscription "Essex County Council (intranet)"
@@ -519,7 +519,7 @@ drush-deploy-straight-to-prod:
   stage: production-postdeploy
   needs: ["deploy-straight-to-prod"]
   before_script:
-    - apk add socat
+    - apt-get install socat
     - az extension add --name containerapp
     - az login --service-principal -u${ARM_CLIENT_ID} -p${ARM_CLIENT_SECRET} -t${ARM_TENANT_ID}
     - az account set --subscription "Essex County Council (intranet)"


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Replace apk with apt-get in gitlab-ci

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?

Pipelines started failing recently as apk isn't in the new Docker image
https://techcommunity.microsoft.com/t5/azure-tools-blog/azure-cli-docker-container-base-linux-image-is-now-azure-linux/ba-p/4236248

- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
