### PR TITLE
fix(LP-85): fixes for published_review_dates View

### DIFF
--- a/config/default/views.view.published_review_dates.yml
+++ b/config/default/views.view.published_review_dates.yml
@@ -2,12 +2,9 @@ uuid: 46595a21-fa64-4902-a44c-0039f89d9451
 langcode: en
 status: true
 dependencies:
-  config:
-    - user.role.authenticated
   module:
     - localgov_review_date
     - node
-    - user
 id: published_review_dates
 label: 'Published/Review Dates'
 module: views
@@ -271,10 +268,8 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: role
-        options:
-          role:
-            authenticated: authenticated
+        type: none
+        options: {  }
       cache:
         type: tag
         options: {  }
@@ -316,7 +311,47 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-      filters: {  }
+      filters:
+        active:
+          id: active
+          table: review_date
+          field: active
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: review_date
+          entity_field: active
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
       row:
@@ -350,7 +385,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - user.roles
       tags: {  }
   block_publish_review_dates:
     id: block_publish_review_dates
@@ -365,5 +399,4 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - user.roles
       tags: {  }


### PR DESCRIPTION
Alter published_review_dates View:

- Display published/review dates for anonymous users. 
- Filter by active review_date (otherwise the first inactive date is displayed)

## Include a summary of what this merge request involves (*)
## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
