### PR TITLE
202503 services parents lp 264

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -9,8 +9,8 @@ xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 database:
-  type: mariadb
-  version: "10.3"
+  type: mysql
+  version: "8.0"
 nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,18 @@
 /bin
 /drush/contrib/
 /vendor/
-/web/
+
+# Ignore web except custom modules.
+/web/*
+!/web/modules/
+/web/modules/contrib/
+/web/modules/README.txt
+!/web/modules/custom/
+!/web/modules/custom/*
 
 # Ignore scaffold files
 /.editorconfig
 /.gitattributes
-/web
 
 # Ignore IDE files
 .idea/

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -41,6 +41,7 @@ module:
   ecc_cookie_compliance: 0
   ecc_menu: 0
   ecc_parents: 0
+  ecc_services_navigation: 0
   editor: 0
   embed: 0
   entity: 0

--- a/config/default/field.field.node.localgov_services_landing.localgov_services_parent.yml
+++ b/config/default/field.field.node.localgov_services_landing.localgov_services_parent.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.localgov_services_parent
     - node.type.localgov_services_landing
+    - node.type.localgov_services_sublanding
     - node.type.localgov_subsites_overview
     - node.type.localgov_subsites_page
 id: node.localgov_services_landing.localgov_services_parent
@@ -18,10 +19,11 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: localgov_services
+  handler: ecc_services_navigation_node_selection
   handler_settings:
     target_bundles:
       localgov_services_landing: localgov_services_landing
+      localgov_services_sublanding: localgov_services_sublanding
       localgov_subsites_overview: localgov_subsites_overview
       localgov_subsites_page: localgov_subsites_page
 field_type: entity_reference

--- a/config/default/field.field.node.localgov_services_page.localgov_services_parent.yml
+++ b/config/default/field.field.node.localgov_services_page.localgov_services_parent.yml
@@ -25,11 +25,12 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: localgov_services
+  handler: ecc_services_navigation_node_selection
   handler_settings:
     target_bundles:
       localgov_guides_overview: localgov_guides_overview
       localgov_guides_page: localgov_guides_page
+      localgov_services_page: localgov_services_page
       localgov_services_landing: localgov_services_landing
       localgov_services_sublanding: localgov_services_sublanding
       localgov_step_by_step_page: localgov_step_by_step_page

--- a/config/default/field.field.node.localgov_services_sublanding.localgov_services_parent.yml
+++ b/config/default/field.field.node.localgov_services_sublanding.localgov_services_parent.yml
@@ -21,10 +21,11 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: localgov_services
+  handler: ecc_services_navigation_node_selection
   handler_settings:
     target_bundles:
       localgov_services_landing: localgov_services_landing
+      localgov_services_sublanding: localgov_services_sublanding
       localgov_subsites_overview: localgov_subsites_overview
       localgov_subsites_page: localgov_subsites_page
 field_type: entity_reference

--- a/web/modules/custom/ecc_d10/README.md
+++ b/web/modules/custom/ecc_d10/README.md
@@ -1,0 +1,3 @@
+# Temporary modules for Drupal 10 upgrade
+
+Delete this folder after the Drupal 10 upgrade.

--- a/web/modules/custom/ecc_d10/ckeditor/ckeditor.info.yml
+++ b/web/modules/custom/ecc_d10/ckeditor/ckeditor.info.yml
@@ -1,0 +1,5 @@
+name: CKEditor for Drupal 10 upgrade
+type: module
+description: Delete after Drupal 10 upgrade
+package: Custom
+core_version_requirement: ^10

--- a/web/modules/custom/ecc_d10/quickedit/quickedit.info.yml
+++ b/web/modules/custom/ecc_d10/quickedit/quickedit.info.yml
@@ -1,0 +1,5 @@
+name: Quickedit for Drupal 10 upgrade
+type: module
+description: Delete after Drupal 10 upgrade
+package: Custom
+core_version_requirement: ^10

--- a/web/modules/custom/ecc_services_navigation/README.md
+++ b/web/modules/custom/ecc_services_navigation/README.md
@@ -1,0 +1,9 @@
+## INTRODUCTION
+
+The ECC Services Navigation module is a way of overriding LGD services
+navigation.
+
+The primary use case for this module is:
+
+- to allow child pages to reference different parent pages than originally
+envisaged.

--- a/web/modules/custom/ecc_services_navigation/config/schema/ecc_services_navigation.schema.yml
+++ b/web/modules/custom/ecc_services_navigation/config/schema/ecc_services_navigation.schema.yml
@@ -1,0 +1,3 @@
+entity_reference_selection.ecc_services_navigation_node_selection:
+  type: entity_reference_selection.default
+  label: 'ECC Services handler settings'

--- a/web/modules/custom/ecc_services_navigation/ecc_services_navigation.info.yml
+++ b/web/modules/custom/ecc_services_navigation/ecc_services_navigation.info.yml
@@ -1,0 +1,7 @@
+name: 'ECC Services Navigation'
+type: module
+description: 'Overrides LGD services navigation'
+package: Custom
+core_version_requirement: ^10
+dependencies:
+  - localgov_services_navigation:localgov_services_navigation

--- a/web/modules/custom/ecc_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
+++ b/web/modules/custom/ecc_services_navigation/src/Plugin/EntityReferenceSelection/ServicesSelection.php
@@ -1,0 +1,291 @@
+<?php declare(strict_types = 1);
+
+namespace Drupal\ecc_services_navigation\Plugin\EntityReferenceSelection;
+
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginBase;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'Services' entity_reference.
+ *
+ * Presently hard coded to work with the hierarchy being in the field named
+ * 'localgov_services_parent'.
+ *
+ * @EntityReferenceSelection(
+ *   id = "ecc_services_navigation_node_selection",
+ *   label = @Translation("ECC Services"),
+ *   group = "ecc_services_navigation_node_selection",
+ *   entity_types = {"node"},
+ * )
+ */
+class ServicesSelection extends SelectionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  public $entityTypeBundleInfo;
+
+  /**
+   * The entity repository.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new ServicesSelection object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info service.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityRepositoryInterface $entity_repository, ModuleHandlerInterface $module_handler, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->entityRepository = $entity_repository;
+    $this->moduleHandler = $module_handler;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity.repository'),
+      $container->get('module_handler'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'target_type' => 'node',
+      'target_bundles' => [],
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $configuration = $this->getConfiguration();
+    $entity_type = $this->entityTypeManager->getDefinition('node');
+    $bundles = $this->entityTypeBundleInfo->getBundleInfo('node');
+
+    $bundle_options = [
+      'localgov_guides_overview' => $bundles['localgov_guides_overview']['label'],
+      'localgov_guides_page' => $bundles['localgov_guides_page']['label'],
+      'localgov_services_page' => $bundles['localgov_services_page']['label'],
+      'localgov_services_landing' => $bundles['localgov_services_landing']['label'],
+      'localgov_services_sublanding' => $bundles['localgov_services_sublanding']['label'],
+      'localgov_step_by_step_page' => $bundles['localgov_step_by_step_page']['label'],
+      'localgov_subsites_overview' => $bundles['localgov_subsites_overview']['label'],
+      'localgov_subsites_page' => $bundles['localgov_subsites_page']['label'],
+    ];
+
+    $form['target_bundles'] = [
+      '#type' => 'checkboxes',
+      '#title' => $entity_type->getBundleLabel(),
+      '#options' => $bundle_options,
+      '#default_value' => (array) $configuration['target_bundles'],
+      '#required' => TRUE,
+      '#multiple' => TRUE,
+      '#element_validate' => [[get_class($this), 'elementValidateFilter']],
+      '#ajax' => TRUE,
+      '#limit_validation_errors' => [],
+    ];
+
+    $form['target_bundles_update'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Update form'),
+      '#limit_validation_errors' => [],
+      '#attributes' => [
+        'class' => ['js-hide'],
+      ],
+      '#submit' => [[EntityReferenceItem::class, 'settingsAjaxSubmit']],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getReferenceableEntities($match = NULL, $match_operator = 'CONTAINS', $limit = 0) {
+    $entities = [];
+    $query = $this->buildEntityQuery($match, $match_operator)
+      ->accessCheck(TRUE);
+    if ($limit > 0) {
+      $query->range(0, $limit);
+    }
+
+    $result = $query->execute();
+
+    if (empty($result)) {
+      return [];
+    }
+
+    $options = [];
+    $entities = $this->entityTypeManager->getStorage('node')->loadMultiple($result);
+    foreach ($entities as $entity_id => $entity) {
+      /** @var \Drupal\node\Entity\Node $entity */
+      $bundle = $entity->bundle();
+      if ($bundle == 'localgov_services_sublanding') {
+        $parent_entity = $entity->localgov_services_parent->entity;
+        if ($parent_entity) {
+          $parent_label = $this->entityRepository->getTranslationFromContext($parent_entity)->label();
+        }
+        else {
+          $parent_label = $this->t('- Missing Parent Landing Page -');
+        }
+        $options[$bundle][$entity_id] = Html::escape($parent_label . ' » ' . $this->entityRepository->getTranslationFromContext($entity)->label());
+      }
+      else {
+        $options[$bundle][$entity_id] = Html::escape($this->entityRepository->getTranslationFromContext($entity)->label());
+      }
+    }
+
+    return $options;
+  }
+
+  /**
+   * Builds an EntityQuery to get referenceable entities.
+   *
+   * @param string|null $match
+   *   (Optional) Text to match the label against. Defaults to NULL.
+   * @param string $match_operator
+   *   (Optional) The operation the matching should be done with. Defaults
+   *   to "CONTAINS".
+   *
+   * @return \Drupal\Core\Entity\Query\QueryInterface
+   *   The EntityQuery object with the basic conditions and sorting applied to
+   *   it.
+   */
+  protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS') {
+    $configuration = $this->getConfiguration();
+    $entity_type = $this->entityTypeManager->getDefinition('node');
+    $query = $this->entityTypeManager->getStorage('node')->getQuery();
+    $query->condition($entity_type->getKey('bundle'), $configuration['target_bundles'], 'IN');
+
+    if (isset($match)) {
+      $tokens = explode(' ', $match);
+      foreach ($tokens as $token) {
+        $or = $query->orConditionGroup();
+        $or->condition('title', $token, $match_operator);
+        $or->condition('localgov_services_parent.entity:node.title', $token, $match_operator);
+        $query->condition($or);
+      }
+    }
+    $query->sort('localgov_services_parent.entity:node.title', 'ASC');
+    $query->sort('title', 'ASC');
+    $query->addTag('node_access');
+    // Adding the 'node_access' tag is sadly insufficient for nodes: core
+    // requires us to also know about the concept of 'published' and
+    // 'unpublished'. We need to do that as long as there are no access control
+    // modules in use on the site. As long as one access control module is
+    // there, it is supposed to handle this check.
+    if (!$this->currentUser->hasPermission('bypass node access') && !$this->moduleHandler->hasImplementations('node_grants')) {
+      $query->condition('status', NodeInterface::PUBLISHED);
+    }
+    $query->addTag('entity_reference');
+    $query->addMetaData('entity_reference_selection_handler', $this);
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function countReferenceableEntities($match = NULL, $match_operator = 'CONTAINS') {
+    $query = $this->buildEntityQuery($match, $match_operator);
+    return $query
+      ->count()
+      ->accessCheck(TRUE)
+      ->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateReferenceableEntities(array $ids) {
+    $result = [];
+    if ($ids) {
+      $entity_type = $this->entityTypeManager->getDefinition('node');
+      $query = $this->buildEntityQuery();
+      $result = $query
+        ->accessCheck(TRUE)
+        ->condition($entity_type->getKey('id'), $ids, 'IN')
+        ->execute();
+    }
+
+    return $result;
+  }
+
+  /**
+   * Form element validation handler; Filters the #value property of an element.
+   */
+  public static function elementValidateFilter(&$element, FormStateInterface $form_state) {
+    $element['#value'] = array_filter($element['#value']);
+    $form_state->setValueForElement($element, $element['#value']);
+  }
+
+}

--- a/web/modules/custom/localgov_restricted_content/config/install/localgov_restricted_content.settings.yml
+++ b/web/modules/custom/localgov_restricted_content/config/install/localgov_restricted_content.settings.yml
@@ -1,0 +1,3 @@
+restricted_content_types:
+  - localgov_news_article
+  - localgov_newsroom

--- a/web/modules/custom/localgov_restricted_content/config/schema/localgov_restricted_content.schema.yml
+++ b/web/modules/custom/localgov_restricted_content/config/schema/localgov_restricted_content.schema.yml
@@ -1,0 +1,9 @@
+settings:
+  type: config_object
+  label: "Restricted Content settings"
+  mapping:
+    restricted_content_types:
+      type: sequence
+      label: 'Content types'
+      sequence:
+        - type: string

--- a/web/modules/custom/localgov_restricted_content/localgov_restricted_content.info.yml
+++ b/web/modules/custom/localgov_restricted_content/localgov_restricted_content.info.yml
@@ -1,0 +1,7 @@
+name: "LocalGov Restricted Content"
+type: module
+description: "Restricted access to content"
+core_version_requirement: ^9 || ^10
+package: LocalGov Drupal
+dependencies:
+  - localgov_core:localgov_core

--- a/web/modules/custom/localgov_restricted_content/localgov_restricted_content.links.menu.yml
+++ b/web/modules/custom/localgov_restricted_content/localgov_restricted_content.links.menu.yml
@@ -1,0 +1,5 @@
+localgov_restricted_content.settings:
+  title: 'Restricted Content settings'
+  parent: system.admin_config_content
+  description: 'Settings for LocalGov restricted content'
+  route_name: localgov_restricted_content.config_form

--- a/web/modules/custom/localgov_restricted_content/localgov_restricted_content.module
+++ b/web/modules/custom/localgov_restricted_content/localgov_restricted_content.module
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * @file
+ * Localgov Restricted Content hooks.
+ */
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeForm;
+
+/**
+ * Implements hook_entity_view_mode_alter().
+ */
+function localgov_restricted_content_entity_view_mode_alter(&$view_mode, $entity, $context) {
+  if (
+    $entity->getEntityTypeId() === 'node' and
+    \Drupal::currentUser()->isAnonymous() and
+    \Drupal::service('localgov_restricted_content.restricted_content')
+      ->isRestricted($entity)
+  ) {
+    // Check the anonymous view display mode exists before using it.
+    $entity_view_display = \Drupal::entityTypeManager()->getStorage('entity_view_display');
+    $anonymous_view_mode =  $view_mode . '_anonymous';
+    if ($entity_view_display->load('node.' . $entity->bundle() . '.' . $anonymous_view_mode)) {
+      $view_mode = $anonymous_view_mode;
+    }
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function localgov_restricted_content_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  /** @var \Drupal\node\NodeForm $node_form */
+  $node_form = $form_state->getBuildInfo()['callback_object'];
+
+  if (!($node_form instanceof NodeForm)) {
+    return;
+  }
+
+  /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+  $entity = $node_form->getEntity();
+
+  // Only display restricted content checkbox for selected content types.
+  $form['localgov_restricted_content']['#access'] = FALSE;
+  $config = \Drupal::config('localgov_restricted_content.settings');
+  foreach ($config->get('restricted_content_types') as $content_type) {
+    if (in_array($form_id, [
+      'node_' . $content_type . '_form',
+      'node_' . $content_type . '_edit_form',
+    ])) {
+      $form['localgov_restricted_content']['#access'] = TRUE;
+
+      /** @var \Drupal\localgov_restricted_content\RestrictedContentInterface $restricted_content */
+      $restricted_content = \Drupal::service('localgov_restricted_content.restricted_content');
+
+      if ($restricted_content->isAncestorRestricted($entity)) {
+        $form['localgov_restricted_content']['#suffix'] = t('<div class="form-item__label option">This is disabled because the page\'s parent is restricted.</div>');
+        $form['localgov_restricted_content']['#disabled'] = TRUE;
+      }
+
+      break;
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function localgov_restricted_content_entity_extra_field_info() {
+  $return = [];
+  $config = \Drupal::config('localgov_restricted_content.settings');
+  foreach ($config->get('restricted_content_types') as $content_type) {
+    $return['node'][$content_type]['display']['restricted_content_sign_in'] = [
+      'label' => t('Sign in link for listings'),
+      'description' => t('Display sign in link on teasers, cards, etc.'),
+      'visible' => TRUE,
+    ];
+    $return['node'][$content_type]['display']['restricted_content_sign_in_with_message'] = [
+      'label' => t('Sign in link for pages'),
+      'description' => t('Display sign in link with message on a restricted content page.'),
+      'visible' => TRUE,
+    ];
+  }
+
+  return $return;
+}
+
+/**
+ * Implements hook_entity_view().
+ *
+ * Display sign-in message and/or link for anonymous users.
+ */
+function localgov_restricted_content_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+  if (\Drupal::currentUser()->isAuthenticated()) {
+    return;
+  }
+  $content = $display->get('content');
+  if (isset($content['restricted_content_sign_in_with_message'])) {
+    $build['sign_in'] = [
+      '#theme' => 'localgov_restricted_content_sign_in_with_message',
+    ];
+  }
+  elseif (isset($content['restricted_content_sign_in'])) {
+    $build['sign_in'] = [
+      '#theme' => 'localgov_restricted_content_sign_in',
+      '#destination' => $entity->toUrl(),
+    ];
+  }
+}
+
+/**
+ * Implements hook_theme().
+ */
+function localgov_restricted_content_theme($existing, $type, $theme, $path) {
+  return [
+    'localgov_restricted_content_sign_in' => [
+      'render element' => 'elements',
+      'variables' => [
+        'destination' => NULL,
+      ],
+    ],
+    'localgov_restricted_content_sign_in_with_message' => [
+      'render element' => 'elements',
+      'variables' => [
+        'destination' => NULL,
+      ],
+    ],
+  ];
+}

--- a/web/modules/custom/localgov_restricted_content/localgov_restricted_content.permissions.yml
+++ b/web/modules/custom/localgov_restricted_content/localgov_restricted_content.permissions.yml
@@ -1,0 +1,2 @@
+administer localgov restricted content:
+  title: 'Administer LocalGov Restricted Content'

--- a/web/modules/custom/localgov_restricted_content/localgov_restricted_content.routing.yml
+++ b/web/modules/custom/localgov_restricted_content/localgov_restricted_content.routing.yml
@@ -1,0 +1,9 @@
+localgov_restricted_content.config_form:
+  path: '/admin/config/content/restricted-content'
+  defaults:
+    _form: '\Drupal\localgov_restricted_content\Form\RestrictedContentConfigForm'
+    _title: 'Restricted Content settings'
+  requirements:
+    _permission: 'administer localgov restricted content'
+  options:
+    _admin_route: TRUE

--- a/web/modules/custom/localgov_restricted_content/localgov_restricted_content.services.yml
+++ b/web/modules/custom/localgov_restricted_content/localgov_restricted_content.services.yml
@@ -1,0 +1,14 @@
+services:
+  localgov_restricted_content.restricted_content:
+    class: Drupal\localgov_restricted_content\RestrictedContent
+    arguments:
+      - '@config.factory'
+
+  # Alter page header.
+  localgov_restricted_content.event_page_header:
+    class: Drupal\localgov_restricted_content\EventSubscriber\PageHeaderSubscriber
+    arguments:
+      - '@current_user'
+      - '@localgov_restricted_content.restricted_content'
+    tags:
+      - { name: 'event_subscriber' }

--- a/web/modules/custom/localgov_restricted_content/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/web/modules/custom/localgov_restricted_content/src/EventSubscriber/PageHeaderSubscriber.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\localgov_restricted_content\EventSubscriber;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\localgov_core\Event\PageHeaderDisplayEvent;
+use Drupal\localgov_restricted_content\RestrictedContentInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Page header event to hide 'lede' on restricted content.
+ *
+ * @package Drupal\localgov_restricted_content\EventSubscriber
+ */
+class PageHeaderSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Account.
+   * @param \Drupal\localgov_restricted_content\RestrictedContentInterface $restrictedContent
+   *   The restricted content service.
+   */
+  public function __construct(
+    protected AccountInterface $account,
+    protected RestrictedContentInterface $restrictedContent) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      PageHeaderDisplayEvent::EVENT_NAME => ['setPageHeader', 0],
+    ];
+  }
+
+  /**
+   * Set page title and lede.
+   */
+  public function setPageHeader(PageHeaderDisplayEvent $event) {
+
+    $node = $event->getEntity();
+
+    if (!$node instanceof NodeInterface) {
+      return;
+    }
+
+    if (
+      $this->restrictedContent->isRestricted($node) and
+      $this->account->isAnonymous()
+    ) {
+      $event->setLede('');
+    }
+  }
+
+}

--- a/web/modules/custom/localgov_restricted_content/src/Form/RestrictedContentConfigForm.php
+++ b/web/modules/custom/localgov_restricted_content/src/Form/RestrictedContentConfigForm.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\localgov_restricted_content\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides settings for localgov_restricted_content module.
+ */
+class RestrictedContentConfigForm extends ConfigFormBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $instance = parent::create($container);
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'localgov_restricted_content_config_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'localgov_restricted_content.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('localgov_restricted_content.settings');
+
+    $restricted_content_types = $config->get('restricted_content_types') ?? [];
+    $content_types = $this->entityTypeManager->getStorage('node_type')->loadMultiple();
+    asort($content_types);
+
+    $form['content_types'] = [
+      '#tree' => TRUE,
+      '#type' => 'fieldset',
+      '#title' => $this->t('Content types'),
+    ];
+
+    foreach ($content_types as $content_type) {
+      $form['content_types'][$content_type->id()] = [
+        '#type' => 'checkbox',
+        '#title' => $content_type->label(),
+        '#default_value' => in_array($content_type->id(), $restricted_content_types),
+      ];
+    }
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('localgov_restricted_content.settings');
+    $restricted_content_types = [];
+    foreach ($form_state->getValue('content_types') as $id => $value) {
+      if ($value) {
+        $restricted_content_types[] = $id;
+      }
+    }
+    $config->set('restricted_content_types', $restricted_content_types);
+    $config->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/web/modules/custom/localgov_restricted_content/src/Plugin/Condition/RestrictedContent.php
+++ b/web/modules/custom/localgov_restricted_content/src/Plugin/Condition/RestrictedContent.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\localgov_restricted_content\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'Restricted Content' condition.
+ *
+ * @Condition(
+ *   id = "restricted_content",
+ *   label = @Translation("Restricted Content"),
+ *   context_definitions = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("Current node"), required = TRUE),
+ *     "user" = @ContextDefinition("entity:user", label = @Translation("User"))
+ *   }
+ * )
+ */
+class RestrictedContent extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Restricted Content service.
+   *
+   * @var \Drupal\localgov_restricted_content\RestrictedContentInterface
+   */
+  protected $restrictedContent;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->restrictedContent = $container->get('localgov_restricted_content.restricted_content');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('@state true if user is not logged in and the current page is restricted content.', [
+      '@state' => empty($this->configuration['negate']) ? $this->t('Return') : $this->t('Do not return'),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['enabled' => FALSE] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enabled'),
+      '#default_value' => $this->configuration['enabled'],
+      '#description' => $this->t('Check if user can view restricted content.'),
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['enabled'] = $form_state->getValue('enabled');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEnabled() {
+    return !empty($this->configuration['enabled']);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Return FALSE if the user is anonymous and the node is restricted.
+   */
+  public function evaluate() {
+    if (!$this->isEnabled()) {
+      return TRUE;
+    }
+    /** @var \Drupal\user\UserInterface $user */
+    $user = $this->getContextValue('user');
+    if ($user instanceof UserInterface and $user->isAuthenticated()) {
+      return TRUE;
+    }
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $this->getContextValue('node');
+    return (
+      $node instanceof NodeInterface and
+      !$this->restrictedContent->isRestricted($node)
+    );
+  }
+
+}

--- a/web/modules/custom/localgov_restricted_content/src/RestrictedContent.php
+++ b/web/modules/custom/localgov_restricted_content/src/RestrictedContent.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\localgov_restricted_content;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * The localgov_restricted_content.restricted_content service.
+ */
+class RestrictedContent implements RestrictedContentInterface {
+
+  public const PARENT_FIELDS = [
+    'localgov_newsroom',
+    'localgov_guides_parent',
+    'localgov_services_parent',
+    'localgov_step_parent',
+    'localgov_subsites_parent',
+  ];
+
+  public const RESTRICTED_CONTENT_FIELD = 'localgov_restricted_content';
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   Config factory.
+   */
+  public function __construct(protected ConfigFactoryInterface $configFactory) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isAncestorRestricted(ContentEntityInterface $entity): bool {
+    foreach ($this::PARENT_FIELDS as $parent_field_option) {
+      if ($entity->hasField($parent_field_option)) {
+        $parent_field = $parent_field_option;
+        break;
+      }
+    }
+    if (isset($parent_field)) {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $parent */
+      if ($parent = $entity->{$parent_field}->entity) {
+        if ($this->isEntityRestrictable($parent)) {
+          if ($parent->{$this::RESTRICTED_CONTENT_FIELD}->value) {
+            return TRUE;
+          }
+          if ($entity->id() === $parent->id()) {
+            // There's no guarantee that the entity isn't its own grandparent,
+            // but abort in the simple case that it's its own parent.
+            // @todo A more complex check is needed for the non-trivial case.
+            return TRUE;
+          }
+          return $this->isAncestorRestricted($parent);
+        }
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isRestricted(ContentEntityInterface $entity): bool {
+    if ($this->isEntityRestrictable($entity)) {
+      if ($entity->{$this::RESTRICTED_CONTENT_FIELD}->value) {
+        return TRUE;
+      }
+      return $this->isAncestorRestricted($entity);
+    }
+    return FALSE;
+  }
+
+  /**
+   * Check if entity is restrictable.
+   *
+   * 1. Entity is a node.
+   * 2. Content type is in the list of restricted content types.
+   * 3. Entity has the restricted content field.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   Entity.
+   *
+   * @return bool
+   *   TRUE if entity is restrictable.
+   */
+  public function isEntityRestrictable(ContentEntityInterface $entity): bool {
+    if ($entity->getEntityTypeId() !== 'node') {
+      return FALSE;
+    }
+
+    $restricted_content_types = &drupal_static(__FUNCTION__);
+    if (!isset($restricted_content_types)) {
+      $config = $this->configFactory->get('localgov_restricted_content.settings');
+      $restricted_content_types = $config->get('restricted_content_types') ?? [];
+    }
+
+    if (!in_array($entity->bundle(), $restricted_content_types)) {
+      return FALSE;
+    }
+
+    return $entity->hasField($this::RESTRICTED_CONTENT_FIELD);
+  }
+
+}

--- a/web/modules/custom/localgov_restricted_content/src/RestrictedContentInterface.php
+++ b/web/modules/custom/localgov_restricted_content/src/RestrictedContentInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\localgov_restricted_content;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Interface for localgov_restricted_content.restricted_content service.
+ */
+interface RestrictedContentInterface {
+
+  /**
+   * Check if the entity is restricted.
+   *
+   * If localgov_restricted_content is TRUE then return TRUE.
+   * if localgov_restricted_content is FALSE then recursively check the entity's
+   * ancestors by following the parent field.
+   * If no ancestors have localgov_restricted_content set to TRUE then return
+   * FALSE.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   Entity.
+   *
+   * @return bool
+   *   TRUE if the entity is restricted.
+   */
+  public function isRestricted(ContentEntityInterface $entity): bool;
+
+  /**
+   * Check if the entity's parent or higher ancestor is restricted.
+   *
+   * Recursively check the entity's ancestors by following the parent field.
+   * If no ancestors have localgov_restricted_content set to TRUE then return
+   * FALSE.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   Entity.
+   *
+   * @return bool
+   *   TRUE if the entity is restricted.
+   */
+  public function isAncestorRestricted(ContentEntityInterface $entity): bool;
+
+}

--- a/web/modules/custom/localgov_restricted_content/templates/localgov-restricted-content-sign-in-with-message.html.twig
+++ b/web/modules/custom/localgov_restricted_content/templates/localgov-restricted-content-sign-in-with-message.html.twig
@@ -1,0 +1,8 @@
+<div>
+  <p>{{ 'This page is restricted, please sign in to see the full page.'|t }}</p>
+  <div>
+    <a href="/user/login?destination={{ destination ?? path('<current>') }}">
+      {{ 'Sign in'|t }}
+    </a>
+  </div>
+</div>

--- a/web/modules/custom/localgov_restricted_content/templates/localgov-restricted-content-sign-in.html.twig
+++ b/web/modules/custom/localgov_restricted_content/templates/localgov-restricted-content-sign-in.html.twig
@@ -1,0 +1,5 @@
+<div>
+  <a href="/user/login?destination={{ destination ?? path('<current>') }}">
+    {{ 'Sign in'|t }}
+  </a>
+</div>

--- a/web/modules/custom/oidc_auto_login/config/install/oidc_auto_login.settings.yml
+++ b/web/modules/custom/oidc_auto_login/config/install/oidc_auto_login.settings.yml
@@ -1,0 +1,6 @@
+enabled: true
+client: client
+header_required: false
+header_key: key
+header_value: value
+cookie_max_age: 60

--- a/web/modules/custom/oidc_auto_login/config/install/rest.resource.oidc_auto_login_allowed.yml
+++ b/web/modules/custom/oidc_auto_login/config/install/rest.resource.oidc_auto_login_allowed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - oidc_auto_login
+    - serialization
+    - user
+id: oidc_auto_login_allowed
+plugin_id: oidc_auto_login_allowed
+granularity: resource
+configuration:
+  methods:
+    - GET
+  formats:
+    - json
+  authentication:
+    - cookie

--- a/web/modules/custom/oidc_auto_login/config/schema/oidc_auto_login.schema.yml
+++ b/web/modules/custom/oidc_auto_login/config/schema/oidc_auto_login.schema.yml
@@ -1,0 +1,22 @@
+oidc_auto_login.settings:
+  type: config_object
+  label: "OpenID Connect Auto-login settings"
+  mapping:
+    enabled:
+      type: boolean
+      label: "Enabled"
+    client:
+      type: string
+      label: "OpenID Connect client id"
+    header_required:
+      type: boolean
+      label: "Require header"
+    header_key:
+      type: string
+      label: "Header key"
+    header_value:
+      type: string
+      label: "Expected header value"
+    cookie_max_age:
+      type: integer
+      label: "Cookie max age"

--- a/web/modules/custom/oidc_auto_login/js/login.js
+++ b/web/modules/custom/oidc_auto_login/js/login.js
@@ -1,0 +1,71 @@
+/**
+ * @file
+ * OpenID Connect Auto Login.
+ */
+(function ($, Drupal) {
+
+  'use strict';
+
+  const autoLoginUrl = "/user/auto-login?destination=";
+
+  const autoLoginUrlPattern = '/user/auto-login';
+
+  const allowAutoLoginEndpoint = '/api/v1/oidc_auto_login_allowed';
+
+  /**
+   * Get a cookie.
+   * @param {string} name
+   * @returns {string}
+   */
+  function getCookie(name) {
+    return document.cookie
+      .split("; ")
+      .find((row) => row.startsWith(name + "="))
+      ?.split("=")[1];
+  }
+
+  /**
+   * Check if auto-login is allowed.
+   * Response from API endpoint must contain JSON {"allow_auto_login": true}.
+   * @returns {Promise<any|boolean>}
+   */
+  async function checkAllowed() {
+    try {
+      const res = await fetch(allowAutoLoginEndpoint);
+      const json = await res.json();
+
+      return json && json.allow_auto_login;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * AutoLogin behaviour.
+   *
+   * @type {Drupal~behavior}
+   */
+  Drupal.behaviors.autoLogin = {
+    attach: function attach(context, settings) {
+      const currentUrl = window.location.href;
+      // Do not run on the auto-login url.
+      if (currentUrl.includes(autoLoginUrlPattern)) {
+        return;
+      }
+
+      // Do not attempt auto-login more than once in this session.
+      if (getCookie('oidc-auto-login') === 'attempted') {
+        return;
+      }
+      const cookieMaxAge= drupalSettings.oidc_auto_login.cookieMaxAge.toString() ?? "300";
+      document.cookie = "oidc-auto-login=attempted; max-age=" + cookieMaxAge;
+
+      if (!(checkAllowed())) {
+        return;
+      }
+
+      const redirectUrl = autoLoginUrl + window.location.pathname;
+      window.location.replace(redirectUrl);
+    }
+  }
+})(jQuery, Drupal);

--- a/web/modules/custom/oidc_auto_login/oidc_auto_login.info.yml
+++ b/web/modules/custom/oidc_auto_login/oidc_auto_login.info.yml
@@ -1,0 +1,7 @@
+name: "OpenID Connect Auto-login"
+type: module
+description: "OpenID Connect Auto-login"
+core_version_requirement: ^9 || ^10
+package: Custom
+dependencies:
+  - openid_connect:openid_connect

--- a/web/modules/custom/oidc_auto_login/oidc_auto_login.libraries.yml
+++ b/web/modules/custom/oidc_auto_login/oidc_auto_login.libraries.yml
@@ -1,0 +1,9 @@
+login:
+  version: 1.0.2
+  header: true
+  js:
+    js/login.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings

--- a/web/modules/custom/oidc_auto_login/oidc_auto_login.links.task.yml
+++ b/web/modules/custom/oidc_auto_login/oidc_auto_login.links.task.yml
@@ -1,0 +1,6 @@
+oidc_auto_login.settings:
+  title: 'Auto-login settings'
+  description: 'Configure OpenID Connect auto-login'
+  route_name: oidc_auto_login.settings
+  base_route: entity.openid_connect_client.list
+  weight: 5

--- a/web/modules/custom/oidc_auto_login/oidc_auto_login.module
+++ b/web/modules/custom/oidc_auto_login/oidc_auto_login.module
@@ -1,0 +1,23 @@
+<?php
+
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function oidc_auto_login_preprocess_page(&$variables) {
+  if (\Drupal::currentUser()->isAnonymous()) {
+    $variables['#attached']['library'][] = 'oidc_auto_login/login';
+    $cookie_max_age = \Drupal::config('oidc_auto_login.settings')->get('cookie_max_age') ?? 300;
+    $variables['#attached']['drupalSettings']['oidc_auto_login']['cookieMaxAge'] = $cookie_max_age;
+  }
+}
+
+/**
+ * Implements hook_user_logout().
+ */
+function oidc_auto_login_user_logout(AccountInterface $account) {
+  // Allow user to logout without being automatically logged in again.
+  $cookie_max_age = \Drupal::config('oidc_auto_login.settings')->get('cookie_max_age') ?? 300;
+  setcookie('oidc-auto-login', 'attempted', time() + $cookie_max_age);
+}

--- a/web/modules/custom/oidc_auto_login/oidc_auto_login.permissions.yml
+++ b/web/modules/custom/oidc_auto_login/oidc_auto_login.permissions.yml
@@ -1,0 +1,4 @@
+administer oidc_auto_login:
+  title: 'Administer OpenID Connect Auto-login'
+  description: 'Allow access to the administration pages for OpenID Connect Auto-login'
+  restrict access: true

--- a/web/modules/custom/oidc_auto_login/oidc_auto_login.routing.yml
+++ b/web/modules/custom/oidc_auto_login/oidc_auto_login.routing.yml
@@ -1,0 +1,14 @@
+oidc_auto_login.login:
+  path: /user/auto-login
+  defaults:
+    _controller: \Drupal\oidc_auto_login\Controller\OidcAutoLoginController::login
+  requirements:
+    _access: 'TRUE'
+
+oidc_auto_login.settings:
+  path: '/admin/config/people/openid-connect/oidc-auto-login'
+  defaults:
+    _title: 'OpenID Connect auto-login settings'
+    _form: '\Drupal\oidc_auto_login\Form\SettingsForm'
+  requirements:
+    _permission: 'administer oidc_auto_login'

--- a/web/modules/custom/oidc_auto_login/src/Controller/OidcAutoLoginController.php
+++ b/web/modules/custom/oidc_auto_login/src/Controller/OidcAutoLoginController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\oidc_auto_login\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Render\RenderContext;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\openid_connect\OpenIDConnectClaims;
+use Drupal\openid_connect\OpenIDConnectSessionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * OpenID Connect Auto-login Controller.
+ *
+ * @package Drupal\oidc_auto_login
+ */
+class OidcAutoLoginController extends ControllerBase {
+
+  /**
+   * Render context.
+   *
+   * @var \Drupal\Core\Render\RenderContext
+   */
+  protected $context;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('openid_connect.claims'),
+      $container->get('openid_connect.session'),
+      $container->get('renderer')
+    );
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\openid_connect\OpenIDConnectClaims $claims
+   *   The OpenID Connect claims service.
+   * @param \Drupal\openid_connect\OpenIDConnectSessionInterface $session
+   *   Session service of the OpenID Connect module.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   Renderer service.
+   */
+  public function __construct(
+    protected OpenIDConnectClaims $claims,
+    protected OpenIDConnectSessionInterface $session,
+    protected RendererInterface $renderer
+  ) {
+    $this->context = new RenderContext();
+  }
+
+  /**
+   * Auto login.
+   *
+   * @return array|\Symfony\Component\HttpFoundation\Response
+   *   A render array or a Response object.
+   */
+  public function login() {
+    if ($this->currentUser()->isAnonymous()) {
+      // Avoid early rendering errors.
+      $response = $this->renderer->executeInRenderContext($this->context, function () {
+        return $this->getAutoLoginResponse();
+      });
+      /** @var \Drupal\Core\Routing\TrustedRedirectResponse $response */
+      return $response;
+    }
+    return new RedirectResponse('/');
+  }
+
+  /**
+   * Authorise and get response.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response|array
+   *   A response object.
+   */
+  protected function getAutoLoginResponse() {
+    try {
+      $client_id = $this->config('oidc_auto_login.settings')
+        ->get('client');
+      /** @var \Drupal\openid_connect\OpenIDConnectClientEntityInterface[] $clients */
+      $clients = $this->entityTypeManager()
+        ->getStorage('openid_connect_client')
+        ->loadByProperties([
+          'id' => $client_id,
+        ]);
+      if (!empty($clients)) {
+        if ($client = $clients[$client_id]) {
+          $plugin = $client->getPlugin();
+          $scopes = $this->claims->getScopes($plugin);
+          $this->session->saveDestination();
+          $this->session->saveOp('login');
+          // If authorisation fails then do not display login screen.
+          return $plugin->authorize($scopes, ['prompt' => 'none']);
+        }
+      }
+    }
+    catch (\Exception $e) {
+    }
+    return new RedirectResponse('/');
+  }
+
+}

--- a/web/modules/custom/oidc_auto_login/src/Form/SettingsForm.php
+++ b/web/modules/custom/oidc_auto_login/src/Form/SettingsForm.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\oidc_auto_login\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Settings form.
+ *
+ * @package Drupal\oidc_auto_login\Form
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'oidc_auto_login_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'oidc_auto_login.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('oidc_auto_login.settings');
+
+    $form['auto_login_settings'] = [
+      '#tree' => FALSE,
+      '#type' => 'fieldset',
+      '#title' => $this->t('Auto-login settings'),
+    ];
+
+    $form['auto_login_settings']['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable auto-login'),
+      '#default_value' => $config->get('enabled'),
+    ];
+
+    $form['auto_login_settings']['client'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('OpenID Connect client id'),
+      '#default_value' => $config->get('client'),
+    ];
+
+    $form['auto_login_settings']['header_required'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Header is required'),
+      '#default_value' => $config->get('header_required'),
+    ];
+
+    $form['auto_login_settings']['header_key'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Header key'),
+      '#default_value' => $config->get('header_key'),
+    ];
+
+    $form['auto_login_settings']['header_value'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Header value'),
+      '#default_value' => $config->get('header_value'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('oidc_auto_login.settings');
+    $config->set('enabled', $form_state->getValue('enabled'));
+    $config->set('client', $form_state->getValue('client'));
+    $config->set('header_required', $form_state->getValue('header_required'));
+    $config->set('header_key', $form_state->getValue('header_key'));
+    $config->set('header_value', $form_state->getValue('header_value'));
+    $config->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/web/modules/custom/oidc_auto_login/src/Plugin/rest/resource/OidcAutoLoginAllowed.php
+++ b/web/modules/custom/oidc_auto_login/src/Plugin/rest/resource/OidcAutoLoginAllowed.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\oidc_auto_login\Plugin\rest\resource;
+
+use Drupal\rest\ModifiedResourceResponse;
+use Drupal\rest\Plugin\ResourceBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a Rest Resource for checking whether auto-login is allowed.
+ *
+ * @RestResource(
+ *   id = "oidc_auto_login_allowed",
+ *   label = @Translation("Allow OpenId Connect auto-login"),
+ *   uri_paths = {
+ *     "canonical" = "/api/v1/oidc_auto_login_allowed",
+ *     "https://www.drupal.org/link-relations/create" = "/api/v1/oidc_auto_login_allowed"
+ *   }
+ * )
+ */
+class OidcAutoLoginAllowed extends ResourceBase {
+
+  /**
+   * Current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->currentUser = $container->get('current_user');
+    $instance->configFactory = $container->get('config.factory');
+    $instance->requestStack = $container->get('request_stack');
+    return $instance;
+  }
+
+  /**
+   * Perform GET request.
+   *
+   * @return \Drupal\rest\ResourceResponseInterface
+   *   ResourceResponse.
+   */
+  public function get() {
+    $auth = FALSE;
+    $config = $this->configFactory->get('oidc_auto_login.settings');
+    if ($config->get('enabled') && $this->currentUser->isAnonymous()) {
+      if ($config->get('header_required')) {
+        $header_key = $config->get('header_key');
+        $expected_header_value = $config->get('header_value');
+        if ($header_key && $expected_header_value) {
+          $actual_header_value = $this->requestStack->getCurrentRequest()->headers->get($header_key);
+        }
+        $auth = !empty($actual_header_value) && $actual_header_value === $expected_header_value;
+      }
+      else {
+        $auth = TRUE;
+      }
+    }
+    return new ModifiedResourceResponse(['allow_auto_login' => $auth]);
+  }
+
+}


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-264
We want to add to the collection of entity bundles available for 'parent' entity reference fields as per the Jira ticket.
To that end we create a custom module with a custom implementation of the `ServicesSelection` plugin found in `localgov_services_navigation` module and then we use that plugin instead of the LGD one for the 'parent' reference fields.

Also in this PR:

1. make gitignore like the one in .gov: to not ignore /web/modules/custom (there was a symlink solution but it caused merry hell with module discovery).
2. swap out mariaDB for mysql 8.0 for DDEV