### PR TITLE
Hide inline links on news articles

### DIFF
--- a/config/default/core.entity_view_display.node.localgov_news_article.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_news_article.default.yml
@@ -38,7 +38,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   field_comments:
     type: comment_default
@@ -47,7 +47,7 @@ content:
       view_mode: default
       pager_id: 0
     third_party_settings: {  }
-    weight: 7
+    weight: 6
     region: content
   field_like_dislike:
     type: like_dislike_formatter
@@ -58,7 +58,7 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-    weight: 6
+    weight: 5
     region: content
   field_media_image:
     type: entity_reference_entity_view
@@ -69,11 +69,6 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-    weight: 1
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
     weight: 0
     region: content
   localgov_news_categories:
@@ -82,7 +77,7 @@ content:
     settings:
       facet: localgov_news_category
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   localgov_news_date:
     type: datetime_custom
@@ -91,7 +86,7 @@ content:
       timezone_override: ''
       date_format: 'j F Y'
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   localgov_news_related:
     type: entity_reference_entity_view
@@ -102,12 +97,12 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-    weight: 5
+    weight: 4
     region: content
 hidden:
   content_moderation_control: true
   entitygroupfield: true
-  field_media_image: true
+  links: true
   localgov_newsroom: true
   localgov_restricted_content: true
   restricted_content_sign_in: true


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-128
we hide the links on the content type because otherwise you get a redundant comment link on nodes with comments