### PR TITLE
Added new parent types to available entity references on service (sub…

### DIFF
--- a/config/default/field.field.node.localgov_services_landing.localgov_services_parent.yml
+++ b/config/default/field.field.node.localgov_services_landing.localgov_services_parent.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.localgov_services_parent
     - node.type.localgov_services_landing
+    - node.type.localgov_services_sublanding
     - node.type.localgov_subsites_overview
     - node.type.localgov_subsites_page
 id: node.localgov_services_landing.localgov_services_parent
@@ -22,6 +23,7 @@ settings:
   handler_settings:
     target_bundles:
       localgov_services_landing: localgov_services_landing
+      localgov_services_sublanding: localgov_services_sublanding
       localgov_subsites_overview: localgov_subsites_overview
       localgov_subsites_page: localgov_subsites_page
 field_type: entity_reference

--- a/config/default/field.field.node.localgov_services_page.localgov_services_parent.yml
+++ b/config/default/field.field.node.localgov_services_page.localgov_services_parent.yml
@@ -25,14 +25,20 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: localgov_services
+  handler: 'default:node'
   handler_settings:
     target_bundles:
       localgov_guides_overview: localgov_guides_overview
       localgov_guides_page: localgov_guides_page
       localgov_services_landing: localgov_services_landing
+      localgov_services_page: localgov_services_page
       localgov_services_sublanding: localgov_services_sublanding
       localgov_step_by_step_page: localgov_step_by_step_page
       localgov_subsites_overview: localgov_subsites_overview
       localgov_subsites_page: localgov_subsites_page
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: localgov_guides_overview
 field_type: entity_reference

--- a/config/default/field.field.node.localgov_services_sublanding.localgov_services_parent.yml
+++ b/config/default/field.field.node.localgov_services_sublanding.localgov_services_parent.yml
@@ -25,6 +25,7 @@ settings:
   handler_settings:
     target_bundles:
       localgov_services_landing: localgov_services_landing
+      localgov_services_sublanding: localgov_services_sublanding
       localgov_subsites_overview: localgov_subsites_overview
       localgov_subsites_page: localgov_subsites_page
 field_type: entity_reference


### PR DESCRIPTION
…) (landing) pages.

After going around the houses with a custom entity reference selection plugin, we realised we could just use core and config.
So switching to `default` selection plugin and adjusting the available entity bundles.

https://eccservicetransformation.atlassian.net/browse/LP-264
