### PR TITLE
Hide links pseudo field for related view mode for news articles

### DIFF
--- a/config/default/core.entity_view_display.node.localgov_news_article.related.yml
+++ b/config/default/core.entity_view_display.node.localgov_news_article.related.yml
@@ -35,7 +35,7 @@ content:
     settings:
       trim_length: 600
     third_party_settings: {  }
-    weight: 4
+    weight: 2
     region: content
   field_media_image:
     type: media_thumbnail
@@ -46,12 +46,7 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 1
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 2
+    weight: 0
     region: content
   localgov_news_date:
     type: datetime_custom
@@ -60,13 +55,14 @@ content:
       timezone_override: ''
       date_format: 'j F Y'
     third_party_settings: {  }
-    weight: 3
+    weight: 1
     region: content
 hidden:
   content_moderation_control: true
   entitygroupfield: true
   field_comments: true
   field_like_dislike: true
+  links: true
   localgov_news_categories: true
   localgov_news_related: true
   localgov_newsroom: true


### PR DESCRIPTION
prevent 'add a comment' from appearing in `related` viewmode on news articles
https://eccservicetransformation.atlassian.net/browse/LP-401